### PR TITLE
Use iterator instead of double channel in `provider.Callback`

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -214,11 +214,14 @@ func (e *Engine) publishAdvForIndex(ctx context.Context, key provider.LookupKey,
 	if !isRm {
 		log.Info("Generating linked list of CIDs for advertisement")
 		// Call the callback
-		chmhs, cherr := e.cb(key)
+		mhIter, err := e.cb(ctx, key)
+		if err != nil {
+			return cid.Undef, err
+		}
 		// Generate the linked list ipld.Link that is added to the
 		// advertisement and used for ingestion.  We do not want to store
 		// anything here, thus the noStoreLsys.
-		lnk, err := generateChunks(noStoreLinkSystem(), chmhs, cherr, maxIngestChunk)
+		lnk, err := generateChunks(noStoreLinkSystem(), mhIter, maxIngestChunk)
 		if err != nil {
 			log.Errorf("Error generating link for linked list structure from list of CIDs for key (%s): %s", string(key), err)
 			return cid.Undef, err

--- a/interface.go
+++ b/interface.go
@@ -68,8 +68,16 @@ type Interface interface {
 	Shutdown(ctx context.Context) error
 }
 
+// MultihashIterator iterates over a list of multihashes.
+type MultihashIterator interface {
+	// Next returns the next multihash in the list of mulitihashes.
+	// The iterator fails fast: errors that occur during iteration are returned immediately.
+	// This function returns a zero multihash and io.EOF when there are no more elements to return.
+	Next() (mh.Multihash, error)
+}
+
 // Callback is used by provider to look up a list of multihashes associated to a key.
 // The callback must produce the same list of multihashes for the same key.
-// See: Interface.NotifyPut, Interface.NotifyRemove
-// TODO: update docs once the iterator return type refactor is done.
-type Callback func(key LookupKey) (<-chan mh.Multihash, <-chan error)
+//
+// See: Interface.NotifyPut, Interface.NotifyRemove, MultihashIterator
+type Callback func(ctx context.Context, key LookupKey) (MultihashIterator, error)

--- a/internal/suppliers/index_mh_iter.go
+++ b/internal/suppliers/index_mh_iter.go
@@ -1,0 +1,51 @@
+package suppliers
+
+import (
+	"context"
+	"io"
+
+	provider "github.com/filecoin-project/indexer-reference-provider"
+	"github.com/ipld/go-car/v2/index"
+	"github.com/multiformats/go-multihash"
+)
+
+var _ provider.MultihashIterator = (*indexMhIterator)(nil)
+
+type indexMhIterator struct {
+	mhch chan multihash.Multihash
+	err  error
+}
+
+func newIndexMhIterator(ctx context.Context, idx index.IterableIndex) *indexMhIterator {
+	mhIterator := indexMhIterator{
+		mhch: make(chan multihash.Multihash, 1),
+	}
+	go func() {
+		if err := idx.ForEach(func(mh multihash.Multihash, _ uint64) error {
+			select {
+			case mhIterator.mhch <- mh:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}); err != nil {
+			mhIterator.err = err
+		}
+		close(mhIterator.mhch)
+	}()
+	return &mhIterator
+}
+
+func (i *indexMhIterator) Next() (multihash.Multihash, error) {
+	mh, ok := <-i.mhch
+	// If channel is closed we have reached the end of stream.
+	// There might also be an error available, which we should return.
+	if !ok {
+		// Check if there is a error first, since returning error must take precedence.
+		if i.err != nil {
+			return nil, i.err
+		}
+		return nil, io.EOF
+	}
+	return mh, nil
+}

--- a/internal/suppliers/index_mh_iter_test.go
+++ b/internal/suppliers/index_mh_iter_test.go
@@ -1,0 +1,126 @@
+package suppliers
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/ipld/go-car/v2"
+	"github.com/ipld/go-car/v2/index"
+	"github.com/multiformats/go-multihash"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIndexMhIterator_NextReturnsMhThenEOFOnHappyPath(t *testing.T) {
+	wantMh, err := multihash.Sum([]byte("fish"), multihash.SHA3_256, -1)
+	require.NoError(t, err)
+
+	subject := newIndexMhIterator(context.Background(), &testIterableIndex{
+		doForEach: func(f func(multihash.Multihash, uint64) error) error {
+			err := f(wantMh, 1)
+			require.NoError(t, err)
+			err = f(wantMh, 2)
+			require.NoError(t, err)
+			return nil
+		},
+	})
+
+	gotMh, err := subject.Next()
+	require.Equal(t, wantMh, gotMh)
+	require.NoError(t, err)
+
+	gotMh, err = subject.Next()
+	require.Equal(t, wantMh, gotMh)
+	require.NoError(t, err)
+
+	gotMh, err = subject.Next()
+	require.Nil(t, gotMh)
+	require.Equal(t, io.EOF, err)
+}
+
+func TestIndexMhIterator_NextReturnsErrorOnUnHappyPath(t *testing.T) {
+	wantMh, err := multihash.Sum([]byte("fish"), multihash.SHA3_256, -1)
+	require.NoError(t, err)
+	wantErr := errors.New("lobster")
+
+	subject := newIndexMhIterator(context.Background(), &testIterableIndex{
+		doForEach: func(f func(multihash.Multihash, uint64) error) error {
+			err := f(wantMh, 1)
+			require.NoError(t, err)
+			return wantErr
+		},
+	})
+
+	gotMh, err := subject.Next()
+	require.NotNil(t, gotMh)
+	require.Nil(t, err)
+
+	gotMh, err = subject.Next()
+	require.Nil(t, gotMh)
+	require.Equal(t, wantErr, err)
+}
+
+func TestNewIndexMhIterator_TimesOutWhenContextTimesOut(t *testing.T) {
+	timedoutCtx, cancelFunc := context.WithTimeout(context.Background(), time.Nanosecond)
+	t.Cleanup(cancelFunc)
+
+	idx, err := car.GenerateIndexFromFile("../../testdata/sample-v1.car")
+	require.NoError(t, err)
+	iterIdx, ok := idx.(index.IterableIndex)
+	require.True(t, ok)
+
+	subject := newIndexMhIterator(timedoutCtx, iterIdx)
+
+	// Assert that eventually deadline exceeded error is returned.
+	// Note, we have to assert eventually, since we can't guarantee whether mh gets added to channel
+	// first or ctx.Done() is selected first.
+	for {
+		_, err = subject.Next()
+		if err != nil {
+			break
+		}
+	}
+	require.EqualError(t, err, "context deadline exceeded")
+}
+
+func TestNewCarSupplier_ReturnsExpectedMultihashes(t *testing.T) {
+	idx, err := car.GenerateIndexFromFile("../../testdata/sample-v1.car")
+	require.NoError(t, err)
+	iterIdx, ok := idx.(index.IterableIndex)
+	require.True(t, ok)
+
+	var wantMhs []multihash.Multihash
+	err = iterIdx.ForEach(func(m multihash.Multihash, _ uint64) error {
+		wantMhs = append(wantMhs, m)
+		return nil
+	})
+	require.NoError(t, err)
+
+	ctx, cancelFunc := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancelFunc)
+	subject := newIndexMhIterator(ctx, iterIdx)
+
+	var gotMhs []multihash.Multihash
+	for {
+		gotNext, err := subject.Next()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		gotMhs = append(gotMhs, gotNext)
+	}
+	require.Equal(t, wantMhs, gotMhs)
+}
+
+var _ index.IterableIndex = (*testIterableIndex)(nil)
+
+type testIterableIndex struct {
+	index.MultihashIndexSorted
+	doForEach func(f func(multihash.Multihash, uint64) error) error
+}
+
+func (t *testIterableIndex) ForEach(f func(multihash.Multihash, uint64) error) error {
+	return t.doForEach(f)
+}


### PR DESCRIPTION
Introduce `MultihashIterator` type to replace the double channel
returned by `provider.Callback`. This is to simplify the usage for
clients.

Require callback to take context in order to gracefully handle the
lifecycle of gorutines that may be started as part of
`MultihashIterator`.

Implement utility class that converts CARv2 `MultihashSortedIndex` into
a `MultihashIterator`. This type is not exported. But may be in the
future if useful to existing clients.

Refactor use of "cid" in names now that provider works with multihashes.