### PR TITLE
Start data transfer

### DIFF
--- a/cmd/provider/daemon.go
+++ b/cmd/provider/daemon.go
@@ -115,6 +115,10 @@ func daemonCommand(cctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	err = dt.Start(context.Background())
+	if err != nil {
+		return err
+	}
 
 	// Starting provider core
 	eng, err := engine.New(ctx, privKey, dt, h, ds, cfg.Ingest.PubSubTopic, cfg.ProviderServer.RetrievalMultiaddrs)

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -110,7 +110,10 @@ func mkEngine(t *testing.T) (*Engine, error) {
 	if err != nil {
 		return nil, err
 	}
-
+	dt.Start(context.Background())
+	if err != nil {
+		return nil, err
+	}
 	return New(context.Background(), priv, dt, h, store, testTopic, nil)
 }
 

--- a/server/provider/libp2p/protocol_test.go
+++ b/server/provider/libp2p/protocol_test.go
@@ -48,7 +48,10 @@ func mkEngine(t *testing.T, h host.Host, testTopic string) (*engine.Engine, erro
 	if err != nil {
 		return nil, err
 	}
-
+	err = dt.Start(context.Background())
+	if err != nil {
+		return nil, err
+	}
 	mhs, _ := utils.RandomMultihashes(10)
 	e, err := engine.New(context.Background(), priv, dt, h, store, testTopic, nil)
 	e.RegisterCallback(utils.ToCallback(mhs))


### PR DESCRIPTION
# Goals

As it turns out, the data transfer module prefers when you don't leave it inactive by forgetting to call Start.