### PR TITLE
Export utility to construct`MultihashIterator` from CAR `IterableIndex`

### DIFF
--- a/index_mh_iter.go
+++ b/index_mh_iter.go
@@ -1,22 +1,27 @@
-package suppliers
+package provider
 
 import (
 	"context"
 	"io"
 
-	provider "github.com/filecoin-project/indexer-reference-provider"
-	"github.com/ipld/go-car/v2/index"
+	carindex "github.com/ipld/go-car/v2/index"
 	"github.com/multiformats/go-multihash"
 )
 
-var _ provider.MultihashIterator = (*indexMhIterator)(nil)
+var _ MultihashIterator = (*indexMhIterator)(nil)
 
 type indexMhIterator struct {
 	mhch chan multihash.Multihash
 	err  error
 }
 
-func newIndexMhIterator(ctx context.Context, idx index.IterableIndex) *indexMhIterator {
+// CarMultihashIterator constructs a new MultihashIterator from a CAR index.
+//
+// A background goroutine is started to supply multihashes via Next method calls.
+// Its lifecycle is controlled by the given context.
+// If the context is canceled before Next reaches io.EOF,
+// then the following Next call will return the context's error.
+func CarMultihashIterator(ctx context.Context, idx carindex.IterableIndex) MultihashIterator {
 	mhIterator := indexMhIterator{
 		mhch: make(chan multihash.Multihash, 1),
 	}

--- a/index_mh_iter_test.go
+++ b/index_mh_iter_test.go
@@ -1,4 +1,4 @@
-package suppliers
+package provider
 
 import (
 	"context"
@@ -17,7 +17,7 @@ func TestIndexMhIterator_NextReturnsMhThenEOFOnHappyPath(t *testing.T) {
 	wantMh, err := multihash.Sum([]byte("fish"), multihash.SHA3_256, -1)
 	require.NoError(t, err)
 
-	subject := newIndexMhIterator(context.Background(), &testIterableIndex{
+	subject := CarMultihashIterator(context.Background(), &testIterableIndex{
 		doForEach: func(f func(multihash.Multihash, uint64) error) error {
 			err := f(wantMh, 1)
 			require.NoError(t, err)
@@ -45,7 +45,7 @@ func TestIndexMhIterator_NextReturnsErrorOnUnHappyPath(t *testing.T) {
 	require.NoError(t, err)
 	wantErr := errors.New("lobster")
 
-	subject := newIndexMhIterator(context.Background(), &testIterableIndex{
+	subject := CarMultihashIterator(context.Background(), &testIterableIndex{
 		doForEach: func(f func(multihash.Multihash, uint64) error) error {
 			err := f(wantMh, 1)
 			require.NoError(t, err)
@@ -66,12 +66,12 @@ func TestNewIndexMhIterator_TimesOutWhenContextTimesOut(t *testing.T) {
 	timedoutCtx, cancelFunc := context.WithTimeout(context.Background(), time.Nanosecond)
 	t.Cleanup(cancelFunc)
 
-	idx, err := car.GenerateIndexFromFile("../../testdata/sample-v1.car")
+	idx, err := car.GenerateIndexFromFile("testdata/sample-v1.car")
 	require.NoError(t, err)
 	iterIdx, ok := idx.(index.IterableIndex)
 	require.True(t, ok)
 
-	subject := newIndexMhIterator(timedoutCtx, iterIdx)
+	subject := CarMultihashIterator(timedoutCtx, iterIdx)
 
 	// Assert that eventually deadline exceeded error is returned.
 	// Note, we have to assert eventually, since we can't guarantee whether mh gets added to channel
@@ -86,7 +86,7 @@ func TestNewIndexMhIterator_TimesOutWhenContextTimesOut(t *testing.T) {
 }
 
 func TestNewCarSupplier_ReturnsExpectedMultihashes(t *testing.T) {
-	idx, err := car.GenerateIndexFromFile("../../testdata/sample-v1.car")
+	idx, err := car.GenerateIndexFromFile("testdata/sample-v1.car")
 	require.NoError(t, err)
 	iterIdx, ok := idx.(index.IterableIndex)
 	require.True(t, ok)
@@ -100,7 +100,7 @@ func TestNewCarSupplier_ReturnsExpectedMultihashes(t *testing.T) {
 
 	ctx, cancelFunc := context.WithTimeout(context.Background(), 10*time.Second)
 	t.Cleanup(cancelFunc)
-	subject := newIndexMhIterator(ctx, iterIdx)
+	subject := CarMultihashIterator(ctx, iterIdx)
 
 	var gotMhs []multihash.Multihash
 	for {

--- a/interface.go
+++ b/interface.go
@@ -70,6 +70,8 @@ type Interface interface {
 }
 
 // MultihashIterator iterates over a list of multihashes.
+//
+// See: CarMultihashIterator.
 type MultihashIterator interface {
 	// Next returns the next multihash in the list of mulitihashes.  The
 	// iterator fails fast: errors that occur during iteration are returned

--- a/internal/suppliers/car_supplier.go
+++ b/internal/suppliers/car_supplier.go
@@ -144,7 +144,7 @@ func (cs *CarSupplier) Callback(ctx context.Context, contextID []byte) (provider
 	if err != nil {
 		return nil, err
 	}
-	return newIndexMhIterator(ctx, idx), nil
+	return provider.CarMultihashIterator(ctx, idx), nil
 }
 
 func (cs *CarSupplier) lookupIterableIndex(contextID []byte) (index.IterableIndex, error) {


### PR DESCRIPTION
Provide an implementation of `MultihashIterator` from CARv2 index. This
is useful to the clients since most will be dealing with CAR
files as a way to supply multihashes to the provider.