### PR TITLE
Cache linked list when the advertisement is generated

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -217,11 +217,10 @@ func (e *Engine) publishAdvForIndex(ctx context.Context, contextID []byte, metad
 			return cid.Undef, err
 		}
 		// Generate the linked list ipld.Link that is added to the
-		// advertisement and used for ingestion.  We do not want to store
-		// anything here, thus the noStoreLsys.
-		lnk, err := generateChunks(noStoreLinkSystem(), mhIter, maxIngestChunk)
+		// advertisement and used for ingestion.
+		lnk, err := generateChunks(e.cachelsys, mhIter, maxIngestChunk)
 		if err != nil {
-			log.Errorf("Error generating link for linked list structure from list of CIDs for contextID (%s): %s", string(contextID), err)
+			log.Errorf("Error generating link from list of CIDs for contextID (%s): %s", string(contextID), err)
 			return cid.Undef, err
 		}
 		cidsLnk = lnk.(cidlink.Link)

--- a/engine/linksystem.go
+++ b/engine/linksystem.go
@@ -249,8 +249,7 @@ func (e *Engine) vanillaLinkSystem() ipld.LinkSystem {
 func noStoreLinkSystem() ipld.LinkSystem {
 	lsys := cidlink.DefaultLinkSystem()
 	lsys.StorageWriteOpener = func(lctx ipld.LinkContext) (io.Writer, ipld.BlockWriteCommitter, error) {
-		buf := bytes.NewBuffer(nil)
-		return buf, func(lnk ipld.Link) error {
+		return io.Discard, func(lnk ipld.Link) error {
 			return nil
 		}, nil
 	}


### PR DESCRIPTION
Previously, the advertisement was generated without caching the associated IPLD linked list, and the list would be generated again, and then cached when an indexer requested it.  Caching when the advertisement is generated means that the list does not need to be regenerated when indexer(s) request it.