### PR TITLE
Print multihashes of a listed ad in base58

### DIFF
--- a/cmd/provider/list.go
+++ b/cmd/provider/list.go
@@ -119,7 +119,7 @@ func doGetAdvertisements(cctx *cli.Context) error {
 
 	if printEntries {
 		for _, mh := range entries {
-			fmt.Printf("  %s\n", mh)
+			fmt.Printf("  %s\n", mh.B58String())
 		}
 		fmt.Println("  ---------------------")
 	}


### PR DESCRIPTION
Print the multihashes of a listed ad in base58 format for better
readability and interoperation with what query endpoint in storetheinde
accepts.