### PR TITLE
Improve reframe memory consumption

### DIFF
--- a/reframe/chunker.go
+++ b/reframe/chunker.go
@@ -11,7 +11,6 @@ import (
 
 type chunker struct {
 	chunkByContextId map[string]*cidsChunk
-	chunkByCid       map[cid.Cid]*cidsChunk
 	currentChunk     *cidsChunk
 	chunkSizeFunc    func() int
 	nonceGen         func() []byte
@@ -35,7 +34,6 @@ func newChunker(chunkSizeFunc func() int, nonceGenFunc func() []byte) *chunker {
 	}
 	ch := &chunker{
 		chunkByContextId: make(map[string]*cidsChunk),
-		chunkByCid:       make(map[cid.Cid]*cidsChunk),
 		chunkSizeFunc:    chunkSizeFunc,
 		nonceGen:         nonceGenFunc,
 	}
@@ -50,23 +48,12 @@ func (ch *chunker) getChunkByContextID(ctxID string) *cidsChunk {
 	return ch.chunkByContextId[ctxID]
 }
 
-func (ch *chunker) getChunkByCID(c cid.Cid) *cidsChunk {
-	return ch.chunkByCid[c]
-}
-
 func (ch *chunker) addChunk(chunk *cidsChunk) {
 	ch.chunkByContextId[contextIDToStr(chunk.ContextID)] = chunk
-	for k := range chunk.Cids {
-		ch.chunkByCid[k] = chunk
-	}
 }
 
 func (ch *chunker) removeChunk(chunk *cidsChunk) {
-	ctxIDStr := contextIDToStr(chunk.ContextID)
-	delete(ch.chunkByContextId, ctxIDStr)
-	for c := range chunk.Cids {
-		delete(ch.chunkByCid, c)
-	}
+	delete(ch.chunkByContextId, contextIDToStr(chunk.ContextID))
 }
 
 func (ch *chunker) newCidsChunk() *cidsChunk {

--- a/reframe/cid_queue.go
+++ b/reframe/cid_queue.go
@@ -15,6 +15,8 @@ type cidQueue struct {
 type cidNode struct {
 	Timestamp time.Time
 	C         cid.Cid
+	// chunk field is private to avoid serialisation
+	chunk *cidsChunk
 }
 
 func newCidQueue() *cidQueue {
@@ -40,6 +42,13 @@ func (cq *cidQueue) removeCidNode(c cid.Cid) {
 	if listNode, ok := cq.listNodeByCid[c]; ok {
 		cq.nodesLl.Remove(listNode)
 		delete(cq.listNodeByCid, c)
+	}
+}
+
+func (cq *cidQueue) assignCidsChunk(c cid.Cid, chunk *cidsChunk) {
+	if elem, ok := cq.listNodeByCid[c]; ok {
+		node := elem.Value.(*cidNode)
+		node.chunk = chunk
 	}
 }
 


### PR DESCRIPTION
Fixed a bug when the same cids have been readvertised over and over again that has led to high disk and RAM usage. Removed some indexes that should improve RAM profile.

Fixes https://github.com/protocol/bifrost-infra/issues/2255

CC @gmasgras