### PR TITLE
Error explicitly when mutlihash lister behaves inconsistently

### DIFF
--- a/engine/chunker/cached_chunker.go
+++ b/engine/chunker/cached_chunker.go
@@ -248,7 +248,7 @@ func (ls *CachedEntriesChunker) Chunk(ctx context.Context, mhi provider.Multihas
 	// Intercept the links that are being stored.
 	// It is safe to swap the StorageWriteOpener, because:
 	//  - Chunk is the only place we expect to write to the linksystem, and
-	//  - calls to Chunk are syncronized using a lock.
+	//  - calls to Chunk are synchronized using a lock.
 	// It is also an efficient way to collecting all the links without having to traverse the dag
 	// from the root link, or make the EntriesChunker interface more complex.
 	ls.lsys.StorageWriteOpener = func(ctx linking.LinkContext) (io.Writer, linking.BlockWriteCommitter, error) {
@@ -267,6 +267,9 @@ func (ls *CachedEntriesChunker) Chunk(ctx context.Context, mhi provider.Multihas
 	root, err := ls.chunker.Chunk(ctx, mhi)
 	if err != nil {
 		return nil, err
+	} else if root == nil {
+		log.Debugw("multihash iterator returned no elements")
+		return nil, nil
 	}
 
 	// Store internal mappings for caching purposes.

--- a/engine/chunker/chunker.go
+++ b/engine/chunker/chunker.go
@@ -12,5 +12,6 @@ import (
 type EntriesChunker interface {
 	// Chunk chunks multihashes supplied by a given provider.MultihashIterator into a chain of
 	// schema.EntryChunk and returns the link of the chain root.
+	// If the given iterator has no elements, this function returns a nil link with no error.
 	Chunk(context.Context, provider.MultihashIterator) (ipld.Link, error)
 }

--- a/engine/chunker/hamt_chunker.go
+++ b/engine/chunker/hamt_chunker.go
@@ -75,14 +75,20 @@ func (h *HamtChunker) Chunk(ctx context.Context, iterator provider.MultihashIter
 	if err != nil {
 		return nil, err
 	}
+	var count int
 	for {
 		mh, err := iterator.Next()
 		if err == io.EOF {
+			// Iterator had no elements
+			if count == 0 {
+				return nil, nil
+			}
 			break
 		}
 		if err != nil {
 			return nil, err
 		}
+		count++
 		if err := ma.AssembleKey().AssignBytes(mh); err != nil {
 			return nil, err
 		}
@@ -90,6 +96,7 @@ func (h *HamtChunker) Chunk(ctx context.Context, iterator provider.MultihashIter
 			return nil, err
 		}
 	}
+	log.Debugw("finished iterating over multihash lister", "mhCount", count)
 	if err := ma.Finish(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Generated entries link from a multihash lister are cached and eventually evicted. They are then regenerated from the original lister whenever required via IPLD link system. The multihash lister, therefore, must be consistent: it must return the same list of multihashes for the same key in order to assure that the link generated will match the previously generated links as mandated by immutable content-addressable data representation as IPLD nodes.

The chages introduced firstly allow chunker interface to return no errors with nil link if a given lister has no elements, and additionally asserts that the link returned by the chunker matches the link expected by the IPLD link system.

An explicit error type is exported to signal mismatch of links and tell the user that the lister is behaving inconsistently.

Fixes #309