### PR TITLE
Print context ID in `provider ls` command

### DIFF
--- a/cmd/provider/list.go
+++ b/cmd/provider/list.go
@@ -132,6 +132,7 @@ func doGetAdvertisements(cctx *cli.Context) error {
 	fmt.Printf("ID:           %s\n", ad.ID)
 	fmt.Printf("PreviousID:   %s\n", ad.PreviousID)
 	fmt.Printf("ProviderID:   %s\n", ad.ProviderID)
+	fmt.Printf("ContextID:    %s\n", base64.StdEncoding.EncodeToString(ad.ContextID))
 	fmt.Printf("Addresses:    %v\n", ad.Addresses)
 	fmt.Printf("Is Remove:    %v\n", ad.IsRemove)
 	fmt.Printf("Metadata :    %s\n", base64.StdEncoding.EncodeToString(ad.Metadata))


### PR DESCRIPTION
To help debug publisher/provider issues also print the context ID in order to reason about correctness of metadata absence among other things.