### PR TITLE
Fix bug in xproviders builder

### DIFF
--- a/engine/xproviders/xproviders_test.go
+++ b/engine/xproviders/xproviders_test.go
@@ -22,7 +22,7 @@ func TestPublish(t *testing.T) {
 	contextID := []byte("test-context")
 	rng := rand.New(rand.NewSource(time.Now().Unix()))
 	addrs := util.StringToMultiaddrs(t, []string{"/ip4/0.0.0.0/tcp/3090", "/ip4/0.0.0.0/tcp/3091"})
-	metadata := make([]byte, 0, 10)
+	metadata := make([]byte, 10)
 	rng.Read(metadata)
 	eps := make([]ep.Info, 2)
 	epIds := make([]peer.ID, len(eps))
@@ -84,15 +84,114 @@ func TestPublish(t *testing.T) {
 			panic("unknown provider")
 		}
 	}
-
 }
 
-func TestPublishWithOnlyMainProviderInTheExtendedList(t *testing.T) {
+func TestMainProviderShouldNotBeAddedAsExtendedIfItsAlreadyOnTheList(t *testing.T) {
+	ctx := testutil.ContextWithTimeout(t)
+	contextID := []byte("test-context")
+	rng := rand.New(rand.NewSource(time.Now().Unix()))
+	addrsStr := []string{"/ip4/0.0.0.0/tcp/3090", "/ip4/0.0.0.0/tcp/3091"}
+	addrs := util.StringToMultiaddrs(t, addrsStr)
+	metadata := make([]byte, 10)
+	rng.Read(metadata)
+
+	eng, err := engine.New()
+	require.NoError(t, err)
+	err = eng.Start(ctx)
+	require.NoError(t, err)
+	defer eng.Shutdown()
+
+	priv, _, providerID := testutil.GenerateKeysAndIdentity(t)
+
+	override := true
+	adv, err := ep.NewAdBuilder(providerID, priv, addrs).
+		WithExtendedProviders(ep.NewInfo(providerID, priv, metadata, addrs)).
+		WithOverride(true).
+		WithContextID(contextID).
+		WithMetadata(metadata).
+		BuildAndSign()
+	require.NoError(t, err)
+	advPeerID, err := adv.VerifySignature()
+	require.NoError(t, err)
+
+	// verify that we can publish successfully
+	c, err := eng.Publish(ctx, *adv)
+	require.NoError(t, err)
+	require.NotEqual(t, cid.Undef, c)
+
+	require.Equal(t, providerID, advPeerID)
+	require.Equal(t, testutil.MultiAddsToString(addrs), adv.Addresses)
+	require.Equal(t, contextID, adv.ContextID)
+	require.Equal(t, schema.NoEntries, adv.Entries)
+	require.Equal(t, false, adv.IsRm)
+	require.Equal(t, metadata, adv.Metadata)
+	require.Equal(t, providerID.String(), adv.Provider)
+	require.Equal(t, override, adv.ExtendedProvider.Override)
+	require.Equal(t, 1, len(adv.ExtendedProvider.Providers))
+
+	ep := adv.ExtendedProvider.Providers[0]
+	require.Equal(t, addrsStr, ep.Addresses)
+	require.Equal(t, metadata, ep.Metadata)
+	require.Equal(t, providerID.String(), ep.ID)
+}
+
+func TestExtendedProvidersShouldNotAllowEmptyAddresses(t *testing.T) {
+	rng := rand.New(rand.NewSource(time.Now().Unix()))
+	addrs := util.StringToMultiaddrs(t, []string{"/ip4/0.0.0.0/tcp/3090", "/ip4/0.0.0.0/tcp/3091"})
+	metadata := make([]byte, 10)
+	rng.Read(metadata)
+
+	priv, _, providerID := testutil.GenerateKeysAndIdentity(t)
+
+	_, err := ep.NewAdBuilder(providerID, priv, addrs).
+		WithExtendedProviders(ep.NewInfo(providerID, priv, metadata, []multiaddr.Multiaddr{})).
+		WithOverride(true).
+		WithContextID([]byte("test-context")).
+		WithMetadata(metadata).
+		BuildAndSign()
+	require.Error(t, err, "addresses of an extended provider can not be empty")
+}
+
+func TestExtendedProvidersShouldAllowEmptyMetadata(t *testing.T) {
+	rng := rand.New(rand.NewSource(time.Now().Unix()))
+	addrs := util.StringToMultiaddrs(t, []string{"/ip4/0.0.0.0/tcp/3090", "/ip4/0.0.0.0/tcp/3091"})
+	metadata := make([]byte, 10)
+	rng.Read(metadata)
+
+	priv, _, providerID := testutil.GenerateKeysAndIdentity(t)
+
+	_, err := ep.NewAdBuilder(providerID, priv, addrs).
+		WithExtendedProviders(ep.NewInfo(providerID, priv, []byte{}, addrs)).
+		WithOverride(true).
+		WithContextID([]byte("test-context")).
+		WithMetadata(metadata).
+		BuildAndSign()
+	require.NoError(t, err)
+}
+
+func TestExtendedProvidersShouldNotAllowInvalidPeerIDs(t *testing.T) {
+	rng := rand.New(rand.NewSource(time.Now().Unix()))
+	addrs := util.StringToMultiaddrs(t, []string{"/ip4/0.0.0.0/tcp/3090", "/ip4/0.0.0.0/tcp/3091"})
+	metadata := make([]byte, 10)
+	rng.Read(metadata)
+
+	priv, _, providerID := testutil.GenerateKeysAndIdentity(t)
+
+	_, err := ep.NewAdBuilder(providerID, priv, addrs).
+		WithExtendedProviders(ep.NewInfo("invalid", priv, []byte{}, addrs)).
+		WithOverride(true).
+		WithContextID([]byte("test-context")).
+		WithMetadata(metadata).
+		BuildAndSign()
+	require.Error(t, err, "invalid extended provider peer id")
+}
+
+func TestMainProviderShouldNotBeAddedAsExtendedIfThereAreNoOthers(t *testing.T) {
 	ctx := testutil.ContextWithTimeout(t)
 	contextID := []byte("test-context")
 	rng := rand.New(rand.NewSource(time.Now().Unix()))
 	addrs := util.StringToMultiaddrs(t, []string{"/ip4/0.0.0.0/tcp/3090", "/ip4/0.0.0.0/tcp/3091"})
-	metadata := make([]byte, 0, 10)
+	metadata := make([]byte, 10)
 	rng.Read(metadata)
 
 	eng, err := engine.New()
@@ -126,17 +225,13 @@ func TestPublishWithOnlyMainProviderInTheExtendedList(t *testing.T) {
 	require.Equal(t, metadata, adv.Metadata)
 	require.Equal(t, providerID.String(), adv.Provider)
 	require.Equal(t, override, adv.ExtendedProvider.Override)
-	require.Equal(t, 1, len(adv.ExtendedProvider.Providers))
-
-	ep := adv.ExtendedProvider.Providers[0]
-	require.Equal(t, testutil.MultiAddsToString(addrs), ep.Addresses)
-	require.Equal(t, metadata, ep.Metadata)
+	require.Equal(t, 0, len(adv.ExtendedProvider.Providers))
 }
 
 func TestPublishFailsIfOverrideIsTrueWithNoContextId(t *testing.T) {
 	rng := rand.New(rand.NewSource(time.Now().Unix()))
 	addrs := util.StringToMultiaddrs(t, []string{"/ip4/0.0.0.0/tcp/3090", "/ip4/0.0.0.0/tcp/3091"})
-	metadata := make([]byte, 0, 10)
+	metadata := make([]byte, 10)
 	rng.Read(metadata)
 	eps := make([]ep.Info, 2)
 	epIds := make([]peer.ID, len(eps))
@@ -159,10 +254,10 @@ func TestPublishFailsIfOverrideIsTrueWithNoContextId(t *testing.T) {
 func randomExtendedProvider(t *testing.T) (peer.ID, ep.Info) {
 	rng := rand.New(rand.NewSource(time.Now().Unix()))
 	priv, _, providerID := testutil.GenerateKeysAndIdentity(t)
-	metadata := make([]byte, 0, 20)
+	metadata := make([]byte, 20)
 	_, err := rng.Read(metadata)
 	require.NoError(t, err)
-	addrs := make([]multiaddr.Multiaddr, 0, 2)
+	addrs := make([]multiaddr.Multiaddr, 2)
 	for i := 0; i < len(addrs); i++ {
 		s := fmt.Sprintf("/ip4/%d.%d.%d.%d/tcp/%d", rng.Int()%255, rng.Int()%255, rng.Int()%255, rng.Int()%255, rng.Int()%10000+1024)
 		ma, err := multiaddr.NewMultiaddr(s)


### PR DESCRIPTION
* Don't allow empty metadata or addresses in the extended provider body
* Don't add the main provider as extended if it's already on the list
* Don't add extended providers at all if non has been provided explicitly

Fixes https://github.com/ipni/index-provider/issues/318

CC @dirkmc 