### PR TITLE
Fall back on no-entries link if chunker link is `nil`

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -467,6 +467,9 @@ func (e *Engine) publishAdvForIndex(ctx context.Context, p peer.ID, addrs []mult
 			lnk, err := e.entriesChunker.Chunk(ctx, mhIter)
 			if err != nil {
 				return cid.Undef, fmt.Errorf("could not generate entries list: %s", err)
+			} else if lnk == nil {
+				log.Warnw("chunking for context ID resulted in no link", "contextID", contextID)
+				lnk = schema.NoEntries
 			}
 			cidsLnk = lnk.(cidlink.Link)
 


### PR DESCRIPTION
During publication of an advertisement it is possible for multihash lister to return no entries for a given context ID. In such case fallback on no-entries link and log a WARN message to notify the user.