### PR TITLE
Daemon needs to use RetrievalMultiaddrs from configuration

### DIFF
--- a/cmd/provider/daemon.go
+++ b/cmd/provider/daemon.go
@@ -140,7 +140,9 @@ func daemonCommand(cctx *cli.Context) error {
 		engine.WithPublisherKind(engine.PublisherKind(cfg.Ingest.PublisherKind)),
 		engine.WithHttpPublisherListenAddr(httpListenAddr),
 		engine.WithHttpPublisherAnnounceAddr(cfg.Ingest.HttpPublisher.AnnounceMultiaddr),
-		engine.WithSyncPolicy(syncPolicy))
+		engine.WithSyncPolicy(syncPolicy),
+		engine.WithRetrievalAddrs(cfg.ProviderServer.RetrievalMultiaddrs...),
+	)
 	if err != nil {
 		return err
 	}

--- a/engine/options.go
+++ b/engine/options.go
@@ -315,9 +315,19 @@ func WithDatastore(ds datastore.Batching) Option {
 // indexing advertisement.
 // If unspecified, the libp2p host listen addresses are used.
 // See: WithHost.
-func WithRetrievalAddrs(addr ...multiaddr.Multiaddr) Option {
+func WithRetrievalAddrs(addrs ...string) Option {
 	return func(o *options) error {
-		o.provider.Addrs = addr
+		if len(addrs) != 0 {
+			maddrs := make([]multiaddr.Multiaddr, len(addrs))
+			for i, a := range addrs {
+				var err error
+				maddrs[i], err = multiaddr.NewMultiaddr(a)
+				if err != nil {
+					return fmt.Errorf("Bad multiaddr %q: %w", a, err)
+				}
+			}
+			o.provider.Addrs = maddrs
+		}
 		return nil
 	}
 }

--- a/engine/options.go
+++ b/engine/options.go
@@ -323,7 +323,7 @@ func WithRetrievalAddrs(addrs ...string) Option {
 				var err error
 				maddrs[i], err = multiaddr.NewMultiaddr(a)
 				if err != nil {
-					return fmt.Errorf("Bad multiaddr %q: %w", a, err)
+					return fmt.Errorf("bad multiaddr %q: %w", a, err)
 				}
 			}
 			o.provider.Addrs = maddrs


### PR DESCRIPTION
The provider daemon was not using the RetrievalMultiaddrs from the configuration file. This caused its advertisements to only contain the local addresses from the host, which would not be acceptable if the host is behind a gateway or NAT.