### PR TITLE
Move from gorilla/mux to http.ServeMux

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/filecoin-project/go-state-types v0.1.0
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/golang/mock v1.6.0
-	github.com/gorilla/mux v1.8.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/ipfs/go-cid v0.3.2
 	github.com/ipfs/go-datastore v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -356,8 +356,6 @@ github.com/gopherjs/gopherjs v1.17.2 h1:fQnZVsXk8uxXIStYb0N4bGk7jeyTalG/wsZjQ25d
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
-github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
-github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/server/admin/http/announce_handler.go
+++ b/server/admin/http/announce_handler.go
@@ -8,6 +8,10 @@ import (
 )
 
 func (s *Server) announceHandler(w http.ResponseWriter, r *http.Request) {
+	if !methodOK(w, r, http.MethodPost) {
+		return
+	}
+
 	adCid, err := s.e.PublishLatest(r.Context())
 	if err != nil {
 		log.Errorw("Could not republish latest advertisement", "err", err)
@@ -21,6 +25,10 @@ func (s *Server) announceHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) announceHttpHandler(w http.ResponseWriter, r *http.Request) {
+	if !methodOK(w, r, http.MethodPost) {
+		return
+	}
+
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		log.Errorw("failed reading import cidlist request", "err", err)

--- a/server/admin/http/car_handler.go
+++ b/server/admin/http/car_handler.go
@@ -17,6 +17,12 @@ type carHandler struct {
 }
 
 func (h *carHandler) handleImport(w http.ResponseWriter, r *http.Request) {
+	if !methodOK(w, r, http.MethodPost) {
+		return
+	}
+	if !matchContentTypeJson(w, r) {
+		return
+	}
 	log.Info("received import CAR request")
 
 	// Decode request.
@@ -66,6 +72,12 @@ func (h *carHandler) handleImport(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *carHandler) handleRemove(w http.ResponseWriter, r *http.Request) {
+	if !methodOK(w, r, http.MethodPost) {
+		return
+	}
+	if !matchContentTypeJson(w, r) {
+		return
+	}
 	log.Info("Received remove CAR request")
 
 	// Decode request.
@@ -108,7 +120,11 @@ func (h *carHandler) handleRemove(w http.ResponseWriter, r *http.Request) {
 	respond(w, http.StatusOK, resp)
 }
 
-func (h *carHandler) handleList(w http.ResponseWriter, _ *http.Request) {
+func (h *carHandler) handleList(w http.ResponseWriter, r *http.Request) {
+	if !methodOK(w, r, http.MethodGet) {
+		return
+	}
+
 	paths, err := h.cs.List(context.Background())
 	if err != nil {
 		err = fmt.Errorf("failed to list CARs %w", err)

--- a/server/admin/http/connect_handler.go
+++ b/server/admin/http/connect_handler.go
@@ -9,6 +9,13 @@ import (
 )
 
 func (s *Server) connectHandler(w http.ResponseWriter, r *http.Request) {
+	if !methodOK(w, r, http.MethodPost) {
+		return
+	}
+	if !matchContentTypeJson(w, r) {
+		return
+	}
+
 	// Decode request
 	var req ConnectReq
 	if _, err := req.ReadFrom(r.Body); err != nil {


### PR DESCRIPTION
There is no benefit to using gorilla/mux for this, so use stdlib http.ServeMux.