### PR TITLE
Upgrade to http delegated routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,16 +105,15 @@ provider import car -l http://localhost:3102 -i <path-to-car-file>
 
 Both CARv1 and CARv2 formats are supported. Index is regenerated on the fly if one is not present.
 
-#### Exposing reframe server from provider (experimental)
+#### Exposing delegated routing server from provider (experimental)
 
-Provider can export a reframe server. [Reframe](https://github.com/ipfs/specs/blob/main/reframe/REFRAME_PROTOCOL.md) is a protocol 
-that allows IPFS nodes to advertise their contents to indexers alongside DHT. Reframe server is off by default. 
-To enable it, add the following configuration block to the provider config file.
+Provider can export a Delegated Routing server. Delegated Routing allows IPFS nodes to advertise their contents to indexers alongside DHT. 
+Delegated Routing server is off by default. To enable it, add the following configuration block to the provider config file.
 
 ```
 {
   ...
-  Reframe {
+  DelegatedRouting {
     ListenMultiaddr: "/ip4/0.0.0.0/tcp/50617 (example)"
   }
   ...

--- a/cmd/provider/internal/config/config.go
+++ b/cmd/provider/internal/config/config.go
@@ -11,14 +11,14 @@ import (
 
 // Config is used to load config files.
 type Config struct {
-	Identity       Identity
-	Datastore      Datastore
-	Ingest         Ingest
-	ProviderServer ProviderServer
-	AdminServer    AdminServer
-	Bootstrap      Bootstrap
-	DirectAnnounce DirectAnnounce
-	Reframe        Reframe
+	Identity         Identity
+	Datastore        Datastore
+	Ingest           Ingest
+	ProviderServer   ProviderServer
+	AdminServer      AdminServer
+	Bootstrap        Bootstrap
+	DirectAnnounce   DirectAnnounce
+	DelegatedRouting DelegatedRouting
 }
 
 const (
@@ -96,13 +96,13 @@ func Load(filePath string) (*Config, error) {
 
 	// Populate with initial values in case they are not present in config.
 	cfg := Config{
-		Bootstrap:      NewBootstrap(),
-		Datastore:      NewDatastore(),
-		Ingest:         NewIngest(),
-		AdminServer:    NewAdminServer(),
-		ProviderServer: NewProviderServer(),
-		DirectAnnounce: NewDirectAnnounce(),
-		Reframe:        NewReframe(),
+		Bootstrap:        NewBootstrap(),
+		Datastore:        NewDatastore(),
+		Ingest:           NewIngest(),
+		AdminServer:      NewAdminServer(),
+		ProviderServer:   NewProviderServer(),
+		DirectAnnounce:   NewDirectAnnounce(),
+		DelegatedRouting: NewDelegatedRouting(),
 	}
 
 	if err = json.NewDecoder(f).Decode(&cfg); err != nil {
@@ -158,5 +158,5 @@ func (c *Config) PopulateDefaults() {
 	c.Datastore.PopulateDefaults()
 	c.Ingest.PopulateDefaults()
 	c.ProviderServer.PopulateDefaults()
-	c.Reframe.PopulateDefaults()
+	c.DelegatedRouting.PopulateDefaults()
 }

--- a/cmd/provider/internal/config/init.go
+++ b/cmd/provider/internal/config/init.go
@@ -20,13 +20,13 @@ func Init(out io.Writer) (*Config, error) {
 
 func InitWithIdentity(identity Identity) (*Config, error) {
 	return &Config{
-		Identity:       identity,
-		Bootstrap:      NewBootstrap(),
-		Datastore:      NewDatastore(),
-		Ingest:         NewIngest(),
-		ProviderServer: NewProviderServer(),
-		AdminServer:    NewAdminServer(),
-		Reframe:        NewReframe(),
+		Identity:         identity,
+		Bootstrap:        NewBootstrap(),
+		Datastore:        NewDatastore(),
+		Ingest:           NewIngest(),
+		ProviderServer:   NewProviderServer(),
+		AdminServer:      NewAdminServer(),
+		DelegatedRouting: NewDelegatedRouting(),
 	}, nil
 }
 

--- a/cmd/provider/internal/config/reframe.go
+++ b/cmd/provider/internal/config/reframe.go
@@ -8,17 +8,17 @@ import (
 )
 
 const (
-	defaultReframeReadTimeout  = Duration(10 * time.Minute)
-	defaultReframeWriteTimeout = Duration(10 * time.Minute)
-	defaultReframeCidTtl       = Duration(24 * time.Hour)
-	defaultReframeChunkSize    = 1_000
-	defaultReframeSnapshotSize = 10_000
-	defaultPageSize            = 5_000
+	defaultDelegatedRoutingReadTimeout  = Duration(10 * time.Minute)
+	defaultDelegatedRoutingWriteTimeout = Duration(10 * time.Minute)
+	defaultDelegatedRoutingCidTtl       = Duration(24 * time.Hour)
+	defaultDelegatedRoutingChunkSize    = 1_000
+	defaultDelegatedRoutingSnapshotSize = 10_000
+	defaultPageSize                     = 5_000
 )
 
-// Reframe tracks the configuration of reframe serber. If specified, index provider will expose a reframe server that will
+// DelegatedRouting tracks the configuration of delegated routing server. If specified, index provider will expose a delegated routing server that will
 // allow an IPFS node to advertise their CIDs through the delegated routing protocol.
-type Reframe struct {
+type DelegatedRouting struct {
 	ListenMultiaddr string
 	ReadTimeout     Duration
 	WriteTimeout    Duration
@@ -30,52 +30,52 @@ type Reframe struct {
 	// SnapshotSize is the maximum number of records in the Provide payload after which it is considered a snapshot.
 	// Snapshots don't have individual timestamps recorded into the datastore. Instead, timestamps are recorded as a binary blob after processing is done.
 	SnapshotSize int
-	// ProviderID is a Peer ID of the IPFS node that the reframe server is expecting advertisements from
+	// ProviderID is a Peer ID of the IPFS node that the delegated routing server is expecting advertisements from
 	ProviderID string
-	// DsPageSize is a size of the database page that is going to be used on reframe server initialisation.
+	// DsPageSize is a size of the database page that is going to be used on delegated routing server initialisation.
 	DsPageSize int
-	// Addrs is a list of multiaddresses of the IPFS node that the reframe server is expecting advertisements from
+	// Addrs is a list of multiaddresses of the IPFS node that the delegated routing server is expecting advertisements from
 	Addrs []string
 }
 
-// NewReframe instantiates a new Reframe config with default values.
-func NewReframe() Reframe {
-	return Reframe{
+// NewDelegatedRouting instantiates a new delegated routing config with default values.
+func NewDelegatedRouting() DelegatedRouting {
+	return DelegatedRouting{
 		// we would like this functionality to be off by default
 		ProviderID:      "",
 		ListenMultiaddr: "",
-		ReadTimeout:     defaultReframeReadTimeout,
-		WriteTimeout:    defaultReframeWriteTimeout,
-		CidTtl:          defaultReframeCidTtl,
-		ChunkSize:       defaultReframeChunkSize,
-		SnapshotSize:    defaultReframeSnapshotSize,
+		ReadTimeout:     defaultDelegatedRoutingReadTimeout,
+		WriteTimeout:    defaultDelegatedRoutingWriteTimeout,
+		CidTtl:          defaultDelegatedRoutingCidTtl,
+		ChunkSize:       defaultDelegatedRoutingChunkSize,
+		SnapshotSize:    defaultDelegatedRoutingSnapshotSize,
 		DsPageSize:      defaultPageSize,
 	}
 }
 
 // PopulateDefaults replaces zero-values in the config with default values.
-func (c *Reframe) PopulateDefaults() {
+func (c *DelegatedRouting) PopulateDefaults() {
 	if c.ReadTimeout == 0 {
-		c.ReadTimeout = defaultReframeReadTimeout
+		c.ReadTimeout = defaultDelegatedRoutingReadTimeout
 	}
 	if c.WriteTimeout == 0 {
-		c.WriteTimeout = defaultReframeWriteTimeout
+		c.WriteTimeout = defaultDelegatedRoutingWriteTimeout
 	}
 	if c.CidTtl == 0 {
-		c.CidTtl = defaultReframeCidTtl
+		c.CidTtl = defaultDelegatedRoutingCidTtl
 	}
 	if c.ChunkSize == 0 {
-		c.ChunkSize = defaultReframeChunkSize
+		c.ChunkSize = defaultDelegatedRoutingChunkSize
 	}
 	if c.SnapshotSize == 0 {
-		c.SnapshotSize = defaultReframeSnapshotSize
+		c.SnapshotSize = defaultDelegatedRoutingSnapshotSize
 	}
 	if c.DsPageSize == 0 {
 		c.DsPageSize = defaultPageSize
 	}
 }
 
-func (as *Reframe) ListenNetAddr() (string, error) {
+func (as *DelegatedRouting) ListenNetAddr() (string, error) {
 	maddr, err := multiaddr.NewMultiaddr(as.ListenMultiaddr)
 	if err != nil {
 		return "", err

--- a/delegatedrouting/chunker.go
+++ b/delegatedrouting/chunker.go
@@ -1,4 +1,4 @@
-package reframe
+package delegatedrouting
 
 import (
 	"context"

--- a/delegatedrouting/cid_queue.go
+++ b/delegatedrouting/cid_queue.go
@@ -1,4 +1,4 @@
-package reframe
+package delegatedrouting
 
 import (
 	"container/list"

--- a/delegatedrouting/ds_wrapper.go
+++ b/delegatedrouting/ds_wrapper.go
@@ -1,4 +1,4 @@
-package reframe
+package delegatedrouting
 
 import (
 	"bytes"

--- a/delegatedrouting/listener_api_test.go
+++ b/delegatedrouting/listener_api_test.go
@@ -1,4 +1,4 @@
-package reframe
+package delegatedrouting
 
 import (
 	"bytes"
@@ -10,7 +10,7 @@ import (
 	"github.com/ipfs/go-datastore"
 )
 
-func ChunkExists(ctx context.Context, listener *ReframeListener, cids []cid.Cid, nonceGen func() []byte) bool {
+func ChunkExists(ctx context.Context, listener *Listener, cids []cid.Cid, nonceGen func() []byte) bool {
 	cidsMap := cidsListToMap(cids)
 	ctxID := listener.chunker.generateContextID(cidsMap)
 	ctxIDStr := contextIDToStr(ctxID)
@@ -45,25 +45,25 @@ func ChunkExists(ctx context.Context, listener *ReframeListener, cids []cid.Cid,
 	return !chunkFromDatastore.Removed
 }
 
-func HasSnapshot(ctx context.Context, listener *ReframeListener) bool {
+func HasSnapshot(ctx context.Context, listener *Listener) bool {
 	return SnapshotsQty(ctx, listener) > 0
 }
 
-func SnapshotsQty(ctx context.Context, listener *ReframeListener) int {
+func SnapshotsQty(ctx context.Context, listener *Listener) int {
 	keys, _ := listener.dsWrapper.getSnapshotChunkKeys(ctx)
 	return len(keys)
 }
 
-func HasCidTimestamp(ctx context.Context, listener *ReframeListener, c cid.Cid) bool {
+func HasCidTimestamp(ctx context.Context, listener *Listener, c cid.Cid) bool {
 	has, err := listener.dsWrapper.ds.Has(ctx, timestampByCidKey(c))
 	return has && err == nil
 }
 
-func WrappedDatastore(listener *ReframeListener) datastore.Datastore {
+func WrappedDatastore(listener *Listener) datastore.Datastore {
 	return listener.dsWrapper.ds
 }
 
-func ChunkNotExist(ctx context.Context, listener *ReframeListener, cids []cid.Cid, nonceGen func() []byte) bool {
+func ChunkNotExist(ctx context.Context, listener *Listener, cids []cid.Cid, nonceGen func() []byte) bool {
 	ctxID := listener.chunker.generateContextID(cidsListToMap(cids))
 	ctxIDStr := contextIDToStr(ctxID)
 	cidsRegistered := false
@@ -87,20 +87,20 @@ func ChunkNotExist(ctx context.Context, listener *ReframeListener, cids []cid.Ci
 
 }
 
-func CidExist(ctx context.Context, listener *ReframeListener, c cid.Cid, requireChunk bool) bool {
+func CidExist(ctx context.Context, listener *Listener, c cid.Cid, requireChunk bool) bool {
 	elem := listener.cidQueue.getNodeByCid(c)
 	return elem != nil && (!requireChunk || elem.Value.(*cidNode).chunk != nil)
 }
 
-func CidNotExist(ctx context.Context, listener *ReframeListener, c cid.Cid) bool {
+func CidNotExist(ctx context.Context, listener *Listener, c cid.Cid) bool {
 	return listener.cidQueue.getNodeByCid(c) == nil
 }
 
-func GetCidTimestampFromDatastore(ctx context.Context, listener *ReframeListener, c cid.Cid) (time.Time, error) {
+func GetCidTimestampFromDatastore(ctx context.Context, listener *Listener, c cid.Cid) (time.Time, error) {
 	return listener.dsWrapper.getCidTimestamp(ctx, c)
 }
 
-func GetCidTimestampFromCache(ctx context.Context, listener *ReframeListener, c cid.Cid) (time.Time, error) {
+func GetCidTimestampFromCache(ctx context.Context, listener *Listener, c cid.Cid) (time.Time, error) {
 	node := listener.cidQueue.getNodeByCid(c)
 	if node == nil {
 		return time.Unix(0, 0), fmt.Errorf("Timestamp not found")
@@ -108,15 +108,15 @@ func GetCidTimestampFromCache(ctx context.Context, listener *ReframeListener, c 
 	return node.Value.(*cidNode).Timestamp, nil
 }
 
-func GetChunk(ctx context.Context, listener *ReframeListener, contextID string) *cidsChunk {
+func GetChunk(ctx context.Context, listener *Listener, contextID string) *cidsChunk {
 	return listener.chunker.getChunkByContextID(contextID)
 }
 
-func GetCurrentChunk(ctx context.Context, listener *ReframeListener) *cidsChunk {
+func GetCurrentChunk(ctx context.Context, listener *Listener) *cidsChunk {
 	return listener.chunker.currentChunk
 }
 
-func GetExpiryQueue(ctx context.Context, listener *ReframeListener) []cid.Cid {
+func GetExpiryQueue(ctx context.Context, listener *Listener) []cid.Cid {
 	cids := make([]cid.Cid, listener.cidQueue.nodesLl.Len())
 	node := listener.cidQueue.nodesLl.Front()
 	cnt := 0

--- a/delegatedrouting/options.go
+++ b/delegatedrouting/options.go
@@ -1,4 +1,4 @@
-package reframe
+package delegatedrouting
 
 const (
 	defaultSnapshotMaxChunkSize = 1_000_000

--- a/delegatedrouting/options_test.go
+++ b/delegatedrouting/options_test.go
@@ -1,13 +1,13 @@
-package reframe_test
+package delegatedrouting_test
 
 import (
 	"testing"
 
-	reframeListener "github.com/ipni/index-provider/reframe"
+	drouting "github.com/ipni/index-provider/delegatedrouting"
 	"github.com/stretchr/testify/require"
 )
 
 func TestOptionsDefaults(t *testing.T) {
-	opts := reframeListener.ApplyOptions()
+	opts := drouting.ApplyOptions()
 	require.Equal(t, 1_000_000, opts.SnapshotMaxChunkSize)
 }

--- a/delegatedrouting/stats_reporter.go
+++ b/delegatedrouting/stats_reporter.go
@@ -1,4 +1,4 @@
-package reframe
+package delegatedrouting
 
 import (
 	"sync/atomic"
@@ -14,15 +14,15 @@ type statsReporter struct {
 }
 
 type stats struct {
-	putAdsSent            int64
-	removeAdsSent         int64
-	cidsProcessed         int64
-	existingCidsProcessed int64
-	cidsExpired           int64
-	reframeCallsReceived  int64
-	reframeCallsProcessed int64
-	chunkCacheMisses      int64
-	chunksNotFound        int64
+	putAdsSent                     int64
+	removeAdsSent                  int64
+	cidsProcessed                  int64
+	existingCidsProcessed          int64
+	cidsExpired                    int64
+	delegatedRoutingCallsReceived  int64
+	delegatedRoutingCallsProcessed int64
+	chunkCacheMisses               int64
+	chunksNotFound                 int64
 }
 
 func newStatsReporter(totalCidsFunc func() int, totalChunksFunc func() int, currentChunkSizeFunc func() int) *statsReporter {
@@ -54,13 +54,13 @@ func (reporter *statsReporter) incCidsExpired() {
 	reporter.s.cidsExpired++
 }
 
-func (reporter *statsReporter) incReframeCallsReceived() {
+func (reporter *statsReporter) incDelegatedRoutingCallsReceived() {
 	// needs to be threadsafe as it gets called from the webserver handler
-	atomic.AddInt64(&reporter.s.reframeCallsReceived, 1)
+	atomic.AddInt64(&reporter.s.delegatedRoutingCallsReceived, 1)
 }
 
-func (reporter *statsReporter) incReframeCallsProcessed() {
-	reporter.s.reframeCallsProcessed++
+func (reporter *statsReporter) incDelegatedRoutingCallsProcessed() {
+	reporter.s.delegatedRoutingCallsProcessed++
 }
 
 func (reporter *statsReporter) incChunkCacheMisses() {

--- a/go.mod
+++ b/go.mod
@@ -8,10 +8,10 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/ipfs/go-cid v0.4.0
 	github.com/ipfs/go-datastore v0.6.0
-	github.com/ipfs/go-delegated-routing v0.7.0
 	github.com/ipfs/go-ds-leveldb v0.5.0
 	github.com/ipfs/go-graphsync v0.14.4
 	github.com/ipfs/go-ipfs-blockstore v1.3.0
+	github.com/ipfs/go-libipfs v0.7.0
 	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/ipfs/kubo v0.18.1
 	github.com/ipld/go-car/v2 v2.8.2
@@ -42,9 +42,11 @@ require (
 	github.com/filecoin-project/go-hamt-ipld/v3 v3.1.0 // indirect
 	github.com/filecoin-project/go-state-types v0.9.9 // indirect
 	github.com/google/pprof v0.0.0-20221203041831-ce31453925ec // indirect
+	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.1 // indirect
 	github.com/ipfs/go-bitfield v1.1.0 // indirect
-	github.com/ipfs/go-libipfs v0.6.1 // indirect
+	github.com/ipfs/go-ipns v0.3.0 // indirect
+	github.com/libp2p/go-libp2p-record v0.2.0 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/onsi/ginkgo/v2 v2.5.1 // indirect
 	github.com/quic-go/qpack v0.4.0 // indirect
@@ -52,7 +54,9 @@ require (
 	github.com/quic-go/qtls-go1-20 v0.1.1 // indirect
 	github.com/quic-go/quic-go v0.33.0 // indirect
 	github.com/quic-go/webtransport-go v0.5.2 // indirect
+	github.com/samber/lo v1.36.0 // indirect
 	github.com/whyrusleeping/cbor-gen v0.0.0-20230126041949-52956bd4c9aa // indirect
+	go.opencensus.io v0.24.0 // indirect
 	go.uber.org/dig v1.15.0 // indirect
 	go.uber.org/fx v1.18.2 // indirect
 	golang.org/x/text v0.7.0 // indirect
@@ -106,14 +110,12 @@ require (
 	github.com/ipfs/go-ipld-cbor v0.0.6 // indirect
 	github.com/ipfs/go-ipld-format v0.4.0 // indirect
 	github.com/ipfs/go-ipld-legacy v0.1.1 // indirect
-	github.com/ipfs/go-ipns v0.3.0 // indirect
 	github.com/ipfs/go-log v1.0.5 // indirect
 	github.com/ipfs/go-merkledag v0.10.0 // indirect
 	github.com/ipfs/go-metrics-interface v0.0.1 // indirect
 	github.com/ipfs/go-peertaskqueue v0.8.1 // indirect
 	github.com/ipfs/go-unixfsnode v1.6.0 // indirect
 	github.com/ipfs/go-verifcid v0.0.2 // indirect
-	github.com/ipld/edelweiss v0.2.0 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
 	github.com/jbenet/go-temp-err-catcher v0.1.0 // indirect
 	github.com/jbenet/goprocess v0.1.4 // indirect
@@ -126,7 +128,6 @@ require (
 	github.com/libp2p/go-flow-metrics v0.1.0 // indirect
 	github.com/libp2p/go-libp2p-asn-util v0.2.0 // indirect
 	github.com/libp2p/go-libp2p-gostream v0.6.0 // indirect
-	github.com/libp2p/go-libp2p-record v0.2.0 // indirect
 	github.com/libp2p/go-msgio v0.3.0 // indirect
 	github.com/libp2p/go-nat v0.1.0 // indirect
 	github.com/libp2p/go-netroute v0.2.1 // indirect
@@ -165,7 +166,6 @@ require (
 	github.com/twmb/murmur3 v1.1.6 // indirect
 	github.com/whyrusleeping/cbor v0.0.0-20171005072247-63513f603b11 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
-	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.10.0 // indirect
 	go.opentelemetry.io/otel/trace v1.13.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -282,6 +282,8 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gopherjs/gopherjs v0.0.0-20190812055157-5d271430af9f/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gopherjs/gopherjs v1.17.2 h1:fQnZVsXk8uxXIStYb0N4bGk7jeyTalG/wsZjQ25dO0g=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
@@ -337,8 +339,6 @@ github.com/ipfs/go-datastore v0.5.0/go.mod h1:9zhEApYMTl17C8YDp7JmU7sQZi2/wqiYh7
 github.com/ipfs/go-datastore v0.5.1/go.mod h1:9zhEApYMTl17C8YDp7JmU7sQZi2/wqiYh73hakZ90Bk=
 github.com/ipfs/go-datastore v0.6.0 h1:JKyz+Gvz1QEZw0LsX1IBn+JFCJQH4SJVFtM4uWU0Myk=
 github.com/ipfs/go-datastore v0.6.0/go.mod h1:rt5M3nNbSO/8q1t4LNkLyUwRs8HupMeN/8O4Vn9YAT8=
-github.com/ipfs/go-delegated-routing v0.7.0 h1:43FyMnKA+8XnyX68Fwg6aoGkqrf8NS5aG7p644s26PU=
-github.com/ipfs/go-delegated-routing v0.7.0/go.mod h1:u4zxjUWIe7APUW5ds9CfD0tJX3vM9JhIeNqA8kE4vHE=
 github.com/ipfs/go-detect-race v0.0.1 h1:qX/xay2W3E4Q1U7d9lNs1sU9nvguX0a7319XbyQ6cOk=
 github.com/ipfs/go-detect-race v0.0.1/go.mod h1:8BNT7shDZPo99Q74BpGMK+4D8Mn4j46UU0LZ723meps=
 github.com/ipfs/go-ds-leveldb v0.5.0 h1:s++MEBbD3ZKc9/8/njrn4flZLnCuY9I79v94gBUNumo=
@@ -378,8 +378,8 @@ github.com/ipfs/go-ipld-legacy v0.1.1 h1:BvD8PEuqwBHLTKqlGFTHSwrwFOMkVESEvwIYwR2
 github.com/ipfs/go-ipld-legacy v0.1.1/go.mod h1:8AyKFCjgRPsQFf15ZQgDB8Din4DML/fOmKZkkFkrIEg=
 github.com/ipfs/go-ipns v0.3.0 h1:ai791nTgVo+zTuq2bLvEGmWP1M0A6kGTXUsgv/Yq67A=
 github.com/ipfs/go-ipns v0.3.0/go.mod h1:3cLT2rbvgPZGkHJoPO1YMJeh6LtkxopCkKFcio/wE24=
-github.com/ipfs/go-libipfs v0.6.1 h1:OSO9cm1H3r4OXfP0MP1Q5UhTnhd2fByGl6CVYyz/Rhk=
-github.com/ipfs/go-libipfs v0.6.1/go.mod h1:FmhKgxMOQA572TK5DA3MZ5GL44ZqsMHIrkgK4gLn4A8=
+github.com/ipfs/go-libipfs v0.7.0 h1:Mi54WJTODaOL2/ZSm5loi3SwI3jI2OuFWUrQIkJ5cpM=
+github.com/ipfs/go-libipfs v0.7.0/go.mod h1:KsIf/03CqhICzyRGyGo68tooiBE2iFbI/rXW7FhAYr0=
 github.com/ipfs/go-log v1.0.0/go.mod h1:JO7RzlMK6rA+CIxFMLOuB6Wf5b81GDiKElL7UPSIKjA=
 github.com/ipfs/go-log v1.0.1/go.mod h1:HuWlQttfN6FWNHRhlY5yMk/lW7evQC0HHGOxEwMRR8I=
 github.com/ipfs/go-log v1.0.4/go.mod h1:oDCg2FkjogeFOhqqb+N39l2RpTNPL6F/StPkB3kPgcs=
@@ -404,8 +404,6 @@ github.com/ipfs/go-verifcid v0.0.2 h1:XPnUv0XmdH+ZIhLGKg6U2vaPaRDXb9urMyNVCE7uvT
 github.com/ipfs/go-verifcid v0.0.2/go.mod h1:40cD9x1y4OWnFXbLNJYRe7MpNvWlMn3LZAG5Wb4xnPU=
 github.com/ipfs/kubo v0.18.1 h1:mF8n2toZkWRc1JXs4pGknqoDGJ9NfP+upy/a8OS3oNg=
 github.com/ipfs/kubo v0.18.1/go.mod h1:VNKTz0OcX28GvsJQSEAprbMqzlSO19f4esoeDX4ZJLQ=
-github.com/ipld/edelweiss v0.2.0 h1:KfAZBP8eeJtrLxLhi7r3N0cBCo7JmwSRhOJp3WSpNjk=
-github.com/ipld/edelweiss v0.2.0/go.mod h1:FJAzJRCep4iI8FOFlRriN9n0b7OuX3T/S9++NpBDmA4=
 github.com/ipld/go-car/v2 v2.8.2 h1:eA3S64qy7Lt+hS8lkO2uXqfNLU7uuGdD/B71hIJw758=
 github.com/ipld/go-car/v2 v2.8.2/go.mod h1:UeIST4b5Je6LEx8GjFysgeCYwxAHKtAcsWxmF6PupNQ=
 github.com/ipld/go-codec-dagpb v1.6.0 h1:9nYazfyu9B1p3NAgfVdpRco3Fs2nFC72DqVsMj6rOcc=
@@ -674,6 +672,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd/go.mod h1:hPqNNc0+uJM6H+SuU8sEs5K5IQeKccPqeSjfgcKGgPk=
+github.com/samber/lo v1.36.0 h1:4LaOxH1mHnbDGhTVE0i1z8v/lWaQW8AIfOD3HU4mSaw=
+github.com/samber/lo v1.36.0/go.mod h1:HLeWcJRRyLKp3+/XBJvOrerCQn9mhdKMHyd7IRlgeQ8=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shurcooL/component v0.0.0-20170202220835-f88ec8f54cc4/go.mod h1:XhFIlyj5a1fBNx5aJTbKoIq0mNaPvOagO+HjB3EtxrY=
 github.com/shurcooL/events v0.0.0-20181021180414-410e4ca65f48/go.mod h1:5u70Mqkb5O5cxEA8nxTsgrgLehJeAw6Oc4Ab1c/P1HM=
@@ -718,6 +718,7 @@ github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -734,6 +735,7 @@ github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpP
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
+github.com/thoas/go-funk v0.9.1 h1:O549iLZqPpTUQ10ykd26sZhzD+rmR5pWhuElrhbC20M=
 github.com/tj/go-spin v1.1.0/go.mod h1:Mg1mzmePZm4dva8Qz60H2lHwmJ2loum4VIrLgVnKwh4=
 github.com/twmb/murmur3 v1.1.6 h1:mqrRot1BRxm+Yct+vavLMou2/iJt0tNVTTC0QoIjaZg=
 github.com/twmb/murmur3 v1.1.6/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=

--- a/server/delegatedrouting/server/options.go
+++ b/server/delegatedrouting/server/options.go
@@ -1,4 +1,4 @@
-package reframeserver
+package server
 
 import "time"
 
@@ -28,7 +28,7 @@ func newOptions(o ...Option) (*options, error) {
 	return opts, nil
 }
 
-// WithListenAddr sets the net address on which the reframe HTTP server is exposed.
+// WithListenAddr sets the net address on which the delegated routing HTTP server is exposed.
 func WithListenAddr(addr string) Option {
 	return func(o *options) error {
 		o.listenAddr = addr


### PR DESCRIPTION
Upgrade from reframe to http delegated rotuing as reframe isn't supported by kubo anymore. Datastore is backwards compatible.

Tested with Kubo v0.19.0.

Fixes https://github.com/ipni/index-provider/issues/312