### PR TITLE
Add periodic ad flush

### DIFF
--- a/cmd/provider/daemon.go
+++ b/cmd/provider/daemon.go
@@ -226,6 +226,7 @@ func daemonCommand(cctx *cli.Context) error {
 			droutingserver.WithListenAddr(droutingAddr),
 			droutingserver.WithReadTimeout(time.Duration(cfg.DelegatedRouting.ReadTimeout)),
 			droutingserver.WithWriteTimeout(time.Duration(cfg.DelegatedRouting.WriteTimeout)),
+			droutingserver.WithAdFlushFrequency(time.Duration(cfg.DelegatedRouting.AdFlushFrequency)),
 		)
 
 		if err != nil {

--- a/cmd/provider/internal/config/delegatedrouting.go
+++ b/cmd/provider/internal/config/delegatedrouting.go
@@ -11,6 +11,7 @@ const (
 	defaultDelegatedRoutingReadTimeout  = Duration(10 * time.Minute)
 	defaultDelegatedRoutingWriteTimeout = Duration(10 * time.Minute)
 	defaultDelegatedRoutingCidTtl       = Duration(24 * time.Hour)
+	defaultAdFlushFrequency             = Duration(10 * time.Minute)
 	defaultDelegatedRoutingChunkSize    = 1_000
 	defaultDelegatedRoutingSnapshotSize = 10_000
 	defaultPageSize                     = 5_000
@@ -24,6 +25,9 @@ type DelegatedRouting struct {
 	WriteTimeout    Duration
 	// CidTtl is a lifetime of a cid after which it is considered expired
 	CidTtl Duration
+	// AdFlushFrequency defines a frequency of a flush operation that is going to be performed on the current chunk. In other words a non empty
+	// current chunk will be converted to an advertisement and published if it's older than this value.
+	AdFlushFrequency Duration
 	// ChunkSize is size of a chunk before it gets advertised to an indexer.
 	// In other words it's a number of CIDs per advertisement
 	ChunkSize int
@@ -42,14 +46,15 @@ type DelegatedRouting struct {
 func NewDelegatedRouting() DelegatedRouting {
 	return DelegatedRouting{
 		// we would like this functionality to be off by default
-		ProviderID:      "",
-		ListenMultiaddr: "",
-		ReadTimeout:     defaultDelegatedRoutingReadTimeout,
-		WriteTimeout:    defaultDelegatedRoutingWriteTimeout,
-		CidTtl:          defaultDelegatedRoutingCidTtl,
-		ChunkSize:       defaultDelegatedRoutingChunkSize,
-		SnapshotSize:    defaultDelegatedRoutingSnapshotSize,
-		DsPageSize:      defaultPageSize,
+		ProviderID:       "",
+		ListenMultiaddr:  "",
+		ReadTimeout:      defaultDelegatedRoutingReadTimeout,
+		WriteTimeout:     defaultDelegatedRoutingWriteTimeout,
+		CidTtl:           defaultDelegatedRoutingCidTtl,
+		ChunkSize:        defaultDelegatedRoutingChunkSize,
+		SnapshotSize:     defaultDelegatedRoutingSnapshotSize,
+		AdFlushFrequency: defaultAdFlushFrequency,
+		DsPageSize:       defaultPageSize,
 	}
 }
 
@@ -63,6 +68,9 @@ func (c *DelegatedRouting) PopulateDefaults() {
 	}
 	if c.CidTtl == 0 {
 		c.CidTtl = defaultDelegatedRoutingCidTtl
+	}
+	if c.AdFlushFrequency == 0 {
+		c.AdFlushFrequency = defaultAdFlushFrequency
 	}
 	if c.ChunkSize == 0 {
 		c.ChunkSize = defaultDelegatedRoutingChunkSize

--- a/cmd/provider/internal/config/delegatedrouting.go
+++ b/cmd/provider/internal/config/delegatedrouting.go
@@ -26,7 +26,7 @@ type DelegatedRouting struct {
 	// CidTtl is a lifetime of a cid after which it is considered expired
 	CidTtl Duration
 	// AdFlushFrequency defines a frequency of a flush operation that is going to be performed on the current chunk. In other words a non empty
-	// current chunk will be converted to an advertisement and published if it's older than this value.
+	// current chunk will be converted to an advertisement and published if it's older than this value. Set to 0 to disable.
 	AdFlushFrequency Duration
 	// ChunkSize is size of a chunk before it gets advertised to an indexer.
 	// In other words it's a number of CIDs per advertisement

--- a/delegatedrouting/listener.go
+++ b/delegatedrouting/listener.go
@@ -499,7 +499,7 @@ func contextIDToStr(contextID []byte) string {
 }
 
 func (listener *Listener) flushWorker(ctx context.Context) {
-	var t *time.Timer
+	t := time.NewTicker(listener.adFlushFrequency)
 
 	flushFunc := func() {
 		// we don't want flush to happen while re-provide is running
@@ -525,7 +525,6 @@ func (listener *Listener) flushWorker(ctx context.Context) {
 			flushFunc()
 		}
 
-		t = time.NewTimer(listener.adFlushFrequency)
 		select {
 		case <-ctx.Done():
 			return

--- a/delegatedrouting/listener.go
+++ b/delegatedrouting/listener.go
@@ -192,7 +192,9 @@ func New(ctx context.Context, engine provider.Interface,
 	listener.stats.start()
 
 	// start flush worker
-	go listener.flushWorker(cctx)
+	if options.AdFlushFrequency > 0 {
+		go listener.flushWorker(cctx)
+	}
 
 	return listener, nil
 }

--- a/delegatedrouting/options.go
+++ b/delegatedrouting/options.go
@@ -1,8 +1,11 @@
 package delegatedrouting
 
+import "time"
+
 const (
 	defaultSnapshotMaxChunkSize = 1_000_000
 	defaultPageSize             = 20_000
+	defaultFlushFrequency       = 10 * time.Minute
 )
 
 type Options struct {
@@ -11,6 +14,9 @@ type Options struct {
 	SnapshotMaxChunkSize int
 	// PageSize defines a maximum number of results that can be returned by a query during datastore initialisation
 	PageSize int
+	// AdFlushFrequency defines a frequency of a flush operation that is going to be performed on the current chunk. In otgher words a non empty
+	// current chunk will be converted to an ad and published.
+	AdFlushFrequency time.Duration
 }
 
 type Option func(*Options)
@@ -27,10 +33,17 @@ func WithPageSize(i int) Option {
 	}
 }
 
+func WithAdFlushFrequency(d time.Duration) Option {
+	return func(o *Options) {
+		o.AdFlushFrequency = d
+	}
+}
+
 func ApplyOptions(opt ...Option) Options {
 	opts := Options{
 		SnapshotMaxChunkSize: defaultSnapshotMaxChunkSize,
 		PageSize:             defaultPageSize,
+		AdFlushFrequency:     defaultFlushFrequency,
 	}
 	for _, o := range opt {
 		o(&opts)

--- a/server/delegatedrouting/server/options.go
+++ b/server/delegatedrouting/server/options.go
@@ -7,9 +7,10 @@ type (
 	Option func(*options) error
 
 	options struct {
-		listenAddr   string
-		readTimeout  time.Duration
-		writeTimeout time.Duration
+		listenAddr       string
+		readTimeout      time.Duration
+		writeTimeout     time.Duration
+		adFlushFrequency time.Duration
 	}
 )
 
@@ -50,6 +51,14 @@ func WithReadTimeout(t time.Duration) Option {
 func WithWriteTimeout(t time.Duration) Option {
 	return func(o *options) error {
 		o.writeTimeout = t
+		return nil
+	}
+}
+
+// WithAdFlushFrequency sets the frequency at which the current chunk is publihsed even if it's not full
+func WithAdFlushFrequency(t time.Duration) Option {
+	return func(o *options) error {
+		o.adFlushFrequency = t
 		return nil
 	}
 }

--- a/server/delegatedrouting/server/server.go
+++ b/server/delegatedrouting/server/server.go
@@ -41,7 +41,17 @@ func New(cidTtl time.Duration,
 		return nil, fmt.Errorf("delegated routing initialisation failed: %s", err)
 	}
 
-	rListener, err := drouting.New(context.Background(), e, cidTtl, chunkSize, snapshotSize, providerID, addrs, ds, nil, drouting.WithPageSize(pageSize))
+	rListener, err := drouting.New(context.Background(),
+		e,
+		cidTtl,
+		chunkSize,
+		snapshotSize,
+		providerID,
+		addrs,
+		ds,
+		nil,
+		drouting.WithPageSize(pageSize),
+		drouting.WithAdFlushFrequency(opts.adFlushFrequency))
 	if err != nil {
 		return nil, fmt.Errorf("delegated routing initialisation failed: %s", err)
 	}


### PR DESCRIPTION
Currently the last chunk gets stuck in the delegated routing server until it's full. That might take a long time given that re-provide is relatively infrequent. This commit adds a worker that periodically checks the current chunk and publishes it if it's not empty and is old enough.

* Add a new configuration parameter `AdFlushFrequency` that defaults to 10 minutes
* Add a worker to delegated routing listener that periodically checks the current chunk