### PR TITLE
Use logic located in go-libipni/test

### DIFF
--- a/cardatatransfer/cardatatransfer_test.go
+++ b/cardatatransfer/cardatatransfer_test.go
@@ -6,10 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math/rand"
 	"testing"
 	"time"
 
+	datatransfer "github.com/filecoin-project/go-data-transfer/v2"
+	retrievaltypes "github.com/filecoin-project/go-retrieval-types"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	dssync "github.com/ipfs/go-datastore/sync"
@@ -25,19 +26,16 @@ import (
 	"github.com/ipld/go-ipld-prime/traversal/selector"
 	"github.com/ipld/go-ipld-prime/traversal/selector/builder"
 	selectorparse "github.com/ipld/go-ipld-prime/traversal/selector/parse"
-	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
-	"github.com/stretchr/testify/require"
-
-	datatransfer "github.com/filecoin-project/go-data-transfer/v2"
-	retrievaltypes "github.com/filecoin-project/go-retrieval-types"
 	"github.com/ipni/go-libipni/metadata"
+	"github.com/ipni/go-libipni/test"
 	"github.com/ipni/index-provider/cardatatransfer"
 	"github.com/ipni/index-provider/supplier"
 	"github.com/ipni/index-provider/testutil"
+	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCarDataTransfer(t *testing.T) {
-	rng := rand.New(rand.NewSource(1413))
 	contextID1 := []byte("cheese")
 	rdOnlyBS1 := testutil.OpenSampleCar(t, "sample-v1-2.car")
 
@@ -52,7 +50,7 @@ func TestCarDataTransfer(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, roots2, 1)
 
-	missingCid := testutil.RandomCids(t, rng, 1)[0]
+	missingCid := test.RandomCids(1)[0]
 	missingContextID := []byte("notFound")
 
 	supplier := &fakeSupplier{blockstores: make(map[string]supplier.ClosableBlockstore)}
@@ -74,7 +72,7 @@ func TestCarDataTransfer(t *testing.T) {
 	pieceCID2 := pieceCIDFromContextID(t, contextID2)
 	missingPieceCID := pieceCIDFromContextID(t, missingContextID)
 
-	incorrectPieceCid := testutil.RandomCids(t, rng, 1)[0]
+	incorrectPieceCid := test.RandomCids(1)[0]
 
 	testCases := map[string]struct {
 		voucher                  datatransfer.TypedVoucher

--- a/delegatedrouting/listener_concurrency_test.go
+++ b/delegatedrouting/listener_concurrency_test.go
@@ -12,10 +12,10 @@ import (
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	leveldb "github.com/ipfs/go-ds-leveldb"
+	"github.com/ipni/go-libipni/test"
 	drouting "github.com/ipni/index-provider/delegatedrouting"
 	"github.com/ipni/index-provider/engine"
 	mock_provider "github.com/ipni/index-provider/mock"
-	"github.com/ipni/index-provider/testutil"
 	"github.com/libp2p/go-libp2p"
 	"github.com/stretchr/testify/require"
 )
@@ -26,7 +26,7 @@ func TestHandleConcurrentRequests(t *testing.T) {
 	snapshotSize := 1000
 	concurrencyFactor := 10
 
-	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
+	pID, priv, _ := test.RandomIdentity()
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -79,7 +79,7 @@ func TestShouldProcessMillionCIDsInThirtySeconds(t *testing.T) {
 
 	h, err := libp2p.New()
 	require.NoError(t, err)
-	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
+	pID, priv, _ := test.RandomIdentity()
 	ctx := context.Background()
 
 	engine, err := engine.New(engine.WithHost(h), engine.WithPublisherKind(engine.DataTransferPublisher))
@@ -111,5 +111,4 @@ func TestShouldProcessMillionCIDsInThirtySeconds(t *testing.T) {
 	provideMany(t, client, ctx, cids)
 
 	require.True(t, time.Since(start) < timeExpectation)
-
 }

--- a/delegatedrouting/listener_test.go
+++ b/delegatedrouting/listener_test.go
@@ -17,10 +17,10 @@ import (
 	"github.com/ipfs/go-libipfs/routing/http/server"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/ipni/go-libipni/metadata"
+	"github.com/ipni/go-libipni/test"
 	drouting "github.com/ipni/index-provider/delegatedrouting"
 	"github.com/ipni/index-provider/engine"
 	mock_provider "github.com/ipni/index-provider/mock"
-	"github.com/ipni/index-provider/testutil"
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -54,7 +54,7 @@ func TestDelegatedRoutingMultihashLister(t *testing.T) {
 	cids[newCid("test2")] = struct{}{}
 	cids[newCid("test3")] = struct{}{}
 
-	_, _, pID := testutil.GenerateKeysAndIdentity(t)
+	pID, _, _ := test.RandomIdentity()
 
 	lister := &drouting.MultihashLister{
 		CidFetcher: func(contextID []byte) (map[cid.Cid]struct{}, error) {
@@ -118,7 +118,8 @@ func TestProvideRoundtrip(t *testing.T) {
 
 	h, err := libp2p.New()
 	require.NoError(t, err)
-	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
+	pID, priv, _ := test.RandomIdentity()
+
 	ctx := context.Background()
 
 	engine, err := engine.New(engine.WithHost(h), engine.WithPublisherKind(engine.DataTransferPublisher))
@@ -177,7 +178,7 @@ func TestProvideRoundtripWithRemove(t *testing.T) {
 
 	h, err := libp2p.New()
 	require.NoError(t, err)
-	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
+	pID, priv, _ := test.RandomIdentity()
 	ctx := context.Background()
 
 	engine, err := engine.New(engine.WithHost(h), engine.WithPublisherKind(engine.DataTransferPublisher))
@@ -233,7 +234,7 @@ func TestAdvertiseTwoChunksWithOneCidInEach(t *testing.T) {
 	chunkSize := 1
 	snapshotSize := 1000
 
-	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
+	pID, priv, _ := test.RandomIdentity()
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -264,7 +265,7 @@ func TestAdvertiseUsingAddrsFromParameters(t *testing.T) {
 	chunkSize := 1
 	snapshotSize := 1000
 
-	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
+	pID, priv, _ := test.RandomIdentity()
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -299,7 +300,7 @@ func TestProvideRegistersCidInDatastore(t *testing.T) {
 	chunkSize := 2
 	snapshotSize := 1000
 
-	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
+	pID, priv, _ := test.RandomIdentity()
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -334,7 +335,7 @@ func TestCidsAreOrderedByArrivalInExpiryQueue(t *testing.T) {
 	chunkSize := 1000
 	snapshotSize := 1000
 
-	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
+	pID, priv, _ := test.RandomIdentity()
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -369,7 +370,7 @@ func TestFullChunkAdvertisedAndRegisteredInDatastore(t *testing.T) {
 	chunkSize := 2
 	snapshotSize := 1000
 
-	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
+	pID, priv, _ := test.RandomIdentity()
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -406,7 +407,7 @@ func TestRemovedChunkIsRemovedFromIndexes(t *testing.T) {
 	chunkSize := 2
 	snapshotSize := 1000
 
-	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
+	pID, priv, _ := test.RandomIdentity()
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -445,7 +446,7 @@ func TestAdvertiseOneChunkWithTwoCidsInIt(t *testing.T) {
 	chunkSize := 2
 	snapshotSize := 1000
 
-	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
+	pID, priv, _ := test.RandomIdentity()
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -475,7 +476,7 @@ func TestDoNotReAdvertiseRepeatedCids(t *testing.T) {
 	chunkSize := 1
 	snapshotSize := 1000
 
-	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
+	pID, priv, _ := test.RandomIdentity()
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -508,7 +509,7 @@ func TestAdvertiseExpiredCidsIfProvidedAgain(t *testing.T) {
 	chunkSize := 1
 	snapshotSize := 1000
 
-	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
+	pID, priv, _ := test.RandomIdentity()
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -546,7 +547,7 @@ func TestRemoveExpiredCidAndReadvertiseChunk(t *testing.T) {
 	chunkSize := 2
 	snapshotSize := 1000
 
-	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
+	pID, priv, _ := test.RandomIdentity()
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -590,7 +591,7 @@ func TestExpireMultipleChunks(t *testing.T) {
 	chunkSize := 1
 	snapshotSize := 1000
 
-	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
+	pID, priv, _ := test.RandomIdentity()
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -628,7 +629,7 @@ func TestDoNotReadvertiseChunkIfAllCidsExpired(t *testing.T) {
 	chunkSize := 1
 	snapshotSize := 1000
 
-	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
+	pID, priv, _ := test.RandomIdentity()
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -666,7 +667,7 @@ func TestDoNotReadvertiseTheSameCids(t *testing.T) {
 	chunkSize := 2
 	snapshotSize := 1000
 
-	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
+	pID, priv, _ := test.RandomIdentity()
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -697,7 +698,7 @@ func TestDoNotLoadRemovedChunksOnInitialisation(t *testing.T) {
 	chunkSize := 1
 	snapshotSize := 1000
 
-	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
+	pID, priv, _ := test.RandomIdentity()
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -737,7 +738,7 @@ func TestMissingCidTimestampsBackfilledOnIntialisation(t *testing.T) {
 	chunkSize := 1
 	snapshotSize := 1000
 
-	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
+	pID, priv, _ := test.RandomIdentity()
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -802,7 +803,7 @@ func TestSameCidNotDuplicatedInTheCurrentChunkIfProvidedTwice(t *testing.T) {
 	chunkSize := 2
 	snapshotSize := 1000
 
-	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
+	pID, priv, _ := test.RandomIdentity()
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -831,7 +832,7 @@ func TestShouldStoreSnapshotInDatastore(t *testing.T) {
 	ttl := time.Hour
 	chunkSize := 1000
 
-	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
+	pID, priv, _ := test.RandomIdentity()
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -872,7 +873,7 @@ func TestShouldNotStoreSnapshotInDatastore(t *testing.T) {
 	ttl := time.Hour
 	chunkSize := 1000
 
-	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
+	pID, priv, _ := test.RandomIdentity()
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -911,7 +912,7 @@ func TestShouldCleanUpTimestampMappingsFromDatastore(t *testing.T) {
 	ttl := time.Hour
 	chunkSize := 1000
 
-	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
+	pID, priv, _ := test.RandomIdentity()
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -957,7 +958,7 @@ func TestShouldCorrectlyMergeSnapshotAndCidTimestamps(t *testing.T) {
 	ttl := time.Hour
 	chunkSize := 1000
 
-	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
+	pID, priv, _ := test.RandomIdentity()
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -1009,7 +1010,7 @@ func TestInitialiseFromDatastoreWithSnapshot(t *testing.T) {
 }
 
 func verifyInitialisationFromDatastore(t *testing.T, snapshotSize int, ttl time.Duration, chunkSize int) {
-	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
+	pID, priv, _ := test.RandomIdentity()
 	// total number of test cids to generate
 	// - has to be not even so that not all of the cids end up included into chunks
 	// - has to span multiple page sizes so that datastore is initialised in pages
@@ -1096,7 +1097,7 @@ func TestCleanUpExpiredCidsThatDontHaveChunk(t *testing.T) {
 	ttl := time.Second
 	chunkSize := 2
 	snapshotSize := 1000
-	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
+	pID, priv, _ := test.RandomIdentity()
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -1137,7 +1138,7 @@ func TestCidsWithoutChunkAreRegisteredInDsAndIndexes(t *testing.T) {
 	ttl := 1 * time.Hour
 	chunkSize := 2
 	snapshotSize := 1000
-	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
+	pID, priv, _ := test.RandomIdentity()
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -1170,7 +1171,7 @@ func TestShouldSplitSnapshotIntoMultipleChunksAndReadThemBack(t *testing.T) {
 
 	h, err := libp2p.New()
 	require.NoError(t, err)
-	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
+	pID, priv, _ := test.RandomIdentity()
 	ctx := context.Background()
 
 	engine, err := engine.New(engine.WithHost(h), engine.WithPublisherKind(engine.DataTransferPublisher))
@@ -1235,7 +1236,7 @@ func TestShouldCleanUpOldSnapshotChunksAfterStoringNewOnes(t *testing.T) {
 
 	h, err := libp2p.New()
 	require.NoError(t, err)
-	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
+	pID, priv, _ := test.RandomIdentity()
 	ctx := context.Background()
 
 	engine, err := engine.New(engine.WithHost(h), engine.WithPublisherKind(engine.DataTransferPublisher))
@@ -1282,7 +1283,7 @@ func TestShouldRecogniseLegacySnapshot(t *testing.T) {
 
 	h, err := libp2p.New()
 	require.NoError(t, err)
-	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
+	pID, priv, _ := test.RandomIdentity()
 	ctx := context.Background()
 
 	engine, err := engine.New(engine.WithHost(h), engine.WithPublisherKind(engine.DataTransferPublisher))
@@ -1342,7 +1343,7 @@ func TestAdsFlush(t *testing.T) {
 	chunkSize := 2
 	snapshotSize := 1000
 	adFlusFreq := 100 * time.Millisecond
-	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
+	pID, priv, _ := test.RandomIdentity()
 
 	ctx := context.Background()
 	defer ctx.Done()

--- a/engine/chunker/chain_chunker_test.go
+++ b/engine/chunker/chain_chunker_test.go
@@ -2,16 +2,15 @@ package chunker_test
 
 import (
 	"context"
-	"math/rand"
 	"testing"
 
 	"github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/ipld/go-ipld-prime/storage/memstore"
 	"github.com/ipni/go-libipni/ingest/schema"
+	"github.com/ipni/go-libipni/test"
 	provider "github.com/ipni/index-provider"
 	"github.com/ipni/index-provider/engine/chunker"
-	"github.com/ipni/index-provider/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,8 +18,7 @@ func TestChainChunker_Chunk(t *testing.T) {
 	ctx := context.TODO()
 	ls := cidlink.DefaultLinkSystem()
 	chunkHasExpectedMhs := func(t *testing.T, subject chunker.EntriesChunker) {
-		rng := rand.New(rand.NewSource(1413))
-		mhs := testutil.RandomMultihashes(t, rng, 100)
+		mhs := test.RandomMultihashes(100)
 		l, err := subject.Chunk(ctx, provider.SliceMultihashIterator(mhs))
 		require.NoError(t, err)
 

--- a/engine/chunker/hamt_chunker_test.go
+++ b/engine/chunker/hamt_chunker_test.go
@@ -2,7 +2,6 @@ package chunker_test
 
 import (
 	"context"
-	"math/rand"
 	"testing"
 
 	hamt "github.com/ipld/go-ipld-adl-hamt"
@@ -10,9 +9,9 @@ import (
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/ipld/go-ipld-prime/node/bindnode"
 	"github.com/ipld/go-ipld-prime/storage/memstore"
+	"github.com/ipni/go-libipni/test"
 	provider "github.com/ipni/index-provider"
 	"github.com/ipni/index-provider/engine/chunker"
-	"github.com/ipni/index-provider/testutil"
 	"github.com/multiformats/go-multicodec"
 	"github.com/stretchr/testify/require"
 )
@@ -74,7 +73,6 @@ func TestNewHamtChunker_ValidatesHamtConfig(t *testing.T) {
 			subject, err := chunker.NewHamtChunker(&ls, test.giveHashAlg, test.giveBitWidth, test.giveBucketSize)
 			if test.wantErr {
 				require.Error(t, err)
-
 			} else {
 				require.NoError(t, err)
 				require.NotNil(t, subject)
@@ -87,8 +85,7 @@ func TestHamtChunker_Chunk(t *testing.T) {
 	ctx := context.TODO()
 	ls := cidlink.DefaultLinkSystem()
 	chunkHasExpectedMhs := func(t *testing.T, subject chunker.EntriesChunker) {
-		rng := rand.New(rand.NewSource(1413))
-		mhs := testutil.RandomMultihashes(t, rng, 100)
+		mhs := test.RandomMultihashes(100)
 		l, err := subject.Chunk(ctx, provider.SliceMultihashIterator(mhs))
 		require.NoError(t, err)
 

--- a/go.mod
+++ b/go.mod
@@ -6,19 +6,19 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/golang/mock v1.6.0
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/ipfs/go-cid v0.4.0
+	github.com/ipfs/go-cid v0.4.1
 	github.com/ipfs/go-datastore v0.6.0
 	github.com/ipfs/go-ds-leveldb v0.5.0
 	github.com/ipfs/go-graphsync v0.14.4
 	github.com/ipfs/go-ipfs-blockstore v1.3.0
 	github.com/ipfs/go-libipfs v0.7.0
 	github.com/ipfs/go-log/v2 v2.5.1
-	github.com/ipfs/kubo v0.18.1
-	github.com/ipld/go-car/v2 v2.8.2
+	github.com/ipfs/kubo v0.19.1
+	github.com/ipld/go-car/v2 v2.9.0
 	github.com/ipld/go-codec-dagpb v1.6.0
 	github.com/ipld/go-ipld-adl-hamt v0.0.0-20220616142416-9004dbd839e0
 	github.com/ipld/go-ipld-prime v0.20.0
-	github.com/ipni/go-libipni v0.0.4
+	github.com/ipni/go-libipni v0.0.5
 	github.com/libp2p/go-libp2p v0.26.4
 	github.com/libp2p/go-libp2p-pubsub v0.9.3
 	github.com/mitchellh/go-homedir v1.1.0
@@ -102,7 +102,7 @@ require (
 	github.com/huin/goupnp v1.0.3 // indirect
 	github.com/ipfs/bbloom v0.0.4 // indirect
 	github.com/ipfs/go-block-format v0.1.1 // indirect
-	github.com/ipfs/go-blockservice v0.5.0 // indirect
+	github.com/ipfs/go-blockservice v0.5.1 // indirect
 	github.com/ipfs/go-ipfs-ds-help v1.1.0 // indirect
 	github.com/ipfs/go-ipfs-exchange-interface v0.2.0 // indirect
 	github.com/ipfs/go-ipfs-pq v0.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -320,8 +320,8 @@ github.com/ipfs/go-block-format v0.0.2/go.mod h1:AWR46JfpcObNfg3ok2JHDUfdiHRgWhJ
 github.com/ipfs/go-block-format v0.0.3/go.mod h1:4LmD4ZUw0mhO+JSKdpWwrzATiEfM7WWgQ8H5l6P8MVk=
 github.com/ipfs/go-block-format v0.1.1 h1:129vSO3zwbsYADcyQWcOYiuCpAqt462SFfqFHdFJhhI=
 github.com/ipfs/go-block-format v0.1.1/go.mod h1:+McEIT+g52p+zz5xGAABGSOKrzmrdX97bc0USBdWPUs=
-github.com/ipfs/go-blockservice v0.5.0 h1:B2mwhhhVQl2ntW2EIpaWPwSCxSuqr5fFA93Ms4bYLEY=
-github.com/ipfs/go-blockservice v0.5.0/go.mod h1:W6brZ5k20AehbmERplmERn8o2Ni3ZZubvAxaIUeaT6w=
+github.com/ipfs/go-blockservice v0.5.1 h1:9pAtkyKAz/skdHTh0kH8VulzWp+qmSDD0aI17TYP/s0=
+github.com/ipfs/go-blockservice v0.5.1/go.mod h1:VpMblFEqG67A/H2sHKAemeH9vlURVavlysbdUI632yk=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.2/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.3/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
@@ -332,8 +332,8 @@ github.com/ipfs/go-cid v0.0.6-0.20200501230655-7c82f3b81c00/go.mod h1:plgt+Y5MnO
 github.com/ipfs/go-cid v0.0.6/go.mod h1:6Ux9z5e+HpkQdckYoX1PG/6xqKspzlEIR5SDmgqgC/I=
 github.com/ipfs/go-cid v0.0.7/go.mod h1:6Ux9z5e+HpkQdckYoX1PG/6xqKspzlEIR5SDmgqgC/I=
 github.com/ipfs/go-cid v0.2.0/go.mod h1:P+HXFDF4CVhaVayiEb4wkAy7zBHxBwsJyt0Y5U6MLro=
-github.com/ipfs/go-cid v0.4.0 h1:a4pdZq0sx6ZSxbCizebnKiMCx/xI/aBBFlB73IgH4rA=
-github.com/ipfs/go-cid v0.4.0/go.mod h1:uQHwDeX4c6CtyrFwdqyhpNcxVewur1M7l7fNU7LKwZk=
+github.com/ipfs/go-cid v0.4.1 h1:A/T3qGvxi4kpKWWcPC/PgbvDA2bjVLO7n4UeVwnbs/s=
+github.com/ipfs/go-cid v0.4.1/go.mod h1:uQHwDeX4c6CtyrFwdqyhpNcxVewur1M7l7fNU7LKwZk=
 github.com/ipfs/go-datastore v0.1.1/go.mod h1:w38XXW9kVFNp57Zj5knbKWM2T+KOZCGDRVNdgPHtbHw=
 github.com/ipfs/go-datastore v0.5.0/go.mod h1:9zhEApYMTl17C8YDp7JmU7sQZi2/wqiYh73hakZ90Bk=
 github.com/ipfs/go-datastore v0.5.1/go.mod h1:9zhEApYMTl17C8YDp7JmU7sQZi2/wqiYh73hakZ90Bk=
@@ -402,10 +402,10 @@ github.com/ipfs/go-unixfsnode v1.6.0 h1:JOSA02yaLylRNi2rlB4ldPr5VcZhcnaIVj5zNLcO
 github.com/ipfs/go-unixfsnode v1.6.0/go.mod h1:PVfoyZkX1B34qzT3vJO4nsLUpRCyhnMuHBznRcXirlk=
 github.com/ipfs/go-verifcid v0.0.2 h1:XPnUv0XmdH+ZIhLGKg6U2vaPaRDXb9urMyNVCE7uvTs=
 github.com/ipfs/go-verifcid v0.0.2/go.mod h1:40cD9x1y4OWnFXbLNJYRe7MpNvWlMn3LZAG5Wb4xnPU=
-github.com/ipfs/kubo v0.18.1 h1:mF8n2toZkWRc1JXs4pGknqoDGJ9NfP+upy/a8OS3oNg=
-github.com/ipfs/kubo v0.18.1/go.mod h1:VNKTz0OcX28GvsJQSEAprbMqzlSO19f4esoeDX4ZJLQ=
-github.com/ipld/go-car/v2 v2.8.2 h1:eA3S64qy7Lt+hS8lkO2uXqfNLU7uuGdD/B71hIJw758=
-github.com/ipld/go-car/v2 v2.8.2/go.mod h1:UeIST4b5Je6LEx8GjFysgeCYwxAHKtAcsWxmF6PupNQ=
+github.com/ipfs/kubo v0.19.1 h1:jQmwct9gurfZcpShmfwZf/0CXSgxgTVWJxx//l4Ob3M=
+github.com/ipfs/kubo v0.19.1/go.mod h1:jD1cb+H5ax9EzxLflHG8dz5LHfuAMO+r00/h3MwYkd4=
+github.com/ipld/go-car/v2 v2.9.0 h1:mkMSfh9NpnfdFe30xBFTQiKZ6+LY+mwOPrq6r56xsPo=
+github.com/ipld/go-car/v2 v2.9.0/go.mod h1:UeIST4b5Je6LEx8GjFysgeCYwxAHKtAcsWxmF6PupNQ=
 github.com/ipld/go-codec-dagpb v1.6.0 h1:9nYazfyu9B1p3NAgfVdpRco3Fs2nFC72DqVsMj6rOcc=
 github.com/ipld/go-codec-dagpb v1.6.0/go.mod h1:ANzFhfP2uMJxRBr8CE+WQWs5UsNa0pYtmKZ+agnUw9s=
 github.com/ipld/go-ipld-adl-hamt v0.0.0-20220616142416-9004dbd839e0 h1:QAI/Ridj0+foHD6epbxmB4ugxz9B4vmNdYSmQLGa05E=
@@ -414,8 +414,8 @@ github.com/ipld/go-ipld-prime v0.9.1-0.20210324083106-dc342a9917db/go.mod h1:KvB
 github.com/ipld/go-ipld-prime v0.20.0 h1:Ud3VwE9ClxpO2LkCYP7vWPc0Fo+dYdYzgxUJZ3uRG4g=
 github.com/ipld/go-ipld-prime v0.20.0/go.mod h1:PzqZ/ZR981eKbgdr3y2DJYeD/8bgMawdGVlJDE8kK+M=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20230102063945-1a409dc236dd h1:gMlw/MhNr2Wtp5RwGdsW23cs+yCuj9k2ON7i9MiJlRo=
-github.com/ipni/go-libipni v0.0.4 h1:wWpt59uwpXEaJzjuCtfAYxG8Lsl2Ykjp67TsoL8Dm80=
-github.com/ipni/go-libipni v0.0.4/go.mod h1:SuUNOKOjqPSA1w3dPopNOzDxDCUndwa8jPCDsG8W/yQ=
+github.com/ipni/go-libipni v0.0.5 h1:hVS/RVgD3WqIVMu+PvqxibaOhFqnBAAjAtlQzddD0NA=
+github.com/ipni/go-libipni v0.0.5/go.mod h1:SuUNOKOjqPSA1w3dPopNOzDxDCUndwa8jPCDsG8W/yQ=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52 h1:QG4CGBqCeuBo6aZlGAamSkxWdgWfZGeE49eUOWJPA4c=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52/go.mod h1:fdg+/X9Gg4AsAIzWpEHwnqd+QY3b7lajxyjE1m4hkq4=
 github.com/jackpal/go-nat-pmp v1.0.2 h1:KzKSgb7qkJvOUTqYl9/Hg/me3pWgBmERKrTGD7BdWus=

--- a/mirror/mirror_env_test.go
+++ b/mirror/mirror_env_test.go
@@ -206,9 +206,11 @@ func (te *testEnv) requireEntriesMirrored(t *testing.T, ctx context.Context, con
 }
 
 func (te *testEnv) syncFromMirrorRecursively(ctx context.Context, c cid.Cid) error {
-	if exists, err := te.mirrorSyncLsStore.Has(ctx, cidlink.Link{Cid: c}.Binary()); err != nil {
+	exists, err := te.mirrorSyncLsStore.Has(ctx, cidlink.Link{Cid: c}.Binary())
+	if err != nil {
 		return err
-	} else if exists {
+	}
+	if exists {
 		return nil
 	}
 	if te.mirrorSyncer == nil {

--- a/server/admin/http/car_handler_test.go
+++ b/server/admin/http/car_handler_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -16,17 +15,16 @@ import (
 	"github.com/ipfs/go-datastore"
 	dssync "github.com/ipfs/go-datastore/sync"
 	"github.com/ipni/go-libipni/metadata"
+	"github.com/ipni/go-libipni/test"
 	provider "github.com/ipni/index-provider"
 	"github.com/ipni/index-provider/cardatatransfer"
 	mock_provider "github.com/ipni/index-provider/mock"
 	"github.com/ipni/index-provider/supplier"
-	"github.com/ipni/index-provider/testutil"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/require"
 )
 
 func Test_importCarHandler(t *testing.T) {
-	rng := rand.New(rand.NewSource(1413))
 	wantKey := []byte("lobster")
 	wantTp, err := cardatatransfer.TransportFromContextID(wantKey)
 	require.NoError(t, err)
@@ -60,7 +58,7 @@ func Test_importCarHandler(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(subject.handleImport)
-	randCids := testutil.RandomCids(t, rng, 1)
+	randCids := test.RandomCids(1)
 	require.NoError(t, err)
 	wantCid := randCids[0]
 
@@ -172,7 +170,6 @@ func Test_importCarAlreadyAdvertised(t *testing.T) {
 }
 
 func Test_removeCarHandler(t *testing.T) {
-	rng := rand.New(rand.NewSource(1413))
 	wantKey := []byte("lobster")
 	req := requireRemoveCarHttpRequestFromKey(t, wantKey)
 
@@ -186,8 +183,8 @@ func Test_removeCarHandler(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(subject.handleRemove)
-	wantCid := testutil.RandomCids(t, rng, 1)[0]
-	requireMockPut(t, mockEng, nil, wantKey, cs, rng)
+	wantCid := test.RandomCids(1)[0]
+	requireMockPut(t, mockEng, nil, wantKey, cs)
 
 	mockEng.
 		EXPECT().
@@ -208,7 +205,6 @@ func Test_removeCarHandler(t *testing.T) {
 }
 
 func Test_removeCarHandlerFail(t *testing.T) {
-	rng := rand.New(rand.NewSource(1413))
 	wantKey := []byte("lobster")
 	req := requireRemoveCarHttpRequestFromKey(t, wantKey)
 
@@ -222,7 +218,7 @@ func Test_removeCarHandlerFail(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(subject.handleRemove)
-	requireMockPut(t, mockEng, nil, wantKey, cs, rng)
+	requireMockPut(t, mockEng, nil, wantKey, cs)
 
 	mockEng.
 		EXPECT().
@@ -307,10 +303,10 @@ func requireRemoveCarHttpRequest(t *testing.T, body io.Reader) *http.Request {
 	return req
 }
 
-func requireMockPut(t *testing.T, mockEng *mock_provider.MockInterface, provider *peer.AddrInfo, key []byte, cs *supplier.CarSupplier, rng *rand.Rand) {
+func requireMockPut(t *testing.T, mockEng *mock_provider.MockInterface, provider *peer.AddrInfo, key []byte, cs *supplier.CarSupplier) {
 	wantTp, err := cardatatransfer.TransportFromContextID(key)
 	require.NoError(t, err)
-	wantCid := testutil.RandomCids(t, rng, 1)[0]
+	wantCid := test.RandomCids(1)[0]
 	wantMetadata := metadata.Default.New(wantTp)
 
 	mockEng.
@@ -322,7 +318,6 @@ func requireMockPut(t *testing.T, mockEng *mock_provider.MockInterface, provider
 }
 
 func Test_ListCarHandler(t *testing.T) {
-	rng := rand.New(rand.NewSource(1413))
 	wantPath := "fish"
 	wantKey := []byte("lobster")
 	wantTp, err := cardatatransfer.TransportFromContextID(wantKey)
@@ -356,7 +351,7 @@ func Test_ListCarHandler(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, respBeforePut.Paths, 0)
 
-	randCids := testutil.RandomCids(t, rng, 1)
+	randCids := test.RandomCids(1)
 	require.NoError(t, err)
 	wantCid := randCids[0]
 

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -2,9 +2,7 @@ package testutil
 
 import (
 	"context"
-	crand "crypto/rand"
 	"io"
-	"math/rand"
 	"os"
 	"path"
 	"path/filepath"
@@ -23,52 +21,11 @@ import (
 	carv2 "github.com/ipld/go-car/v2"
 	"github.com/ipld/go-car/v2/blockstore"
 	"github.com/ipld/go-ipld-prime"
-	"github.com/ipni/go-libipni/ingest/schema"
-	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/multiformats/go-multiaddr"
-	"github.com/multiformats/go-multihash"
 	"github.com/stretchr/testify/require"
 )
-
-func NewID(t *testing.T) peer.ID {
-	_, pub, err := crypto.GenerateEd25519Key(crand.Reader)
-	require.NoError(t, err)
-
-	id, err := peer.IDFromPublicKey(pub)
-	require.NoError(t, err)
-
-	return id
-}
-
-func RandomCids(t testing.TB, rng *rand.Rand, n int) []cid.Cid {
-	prefix := schema.Linkproto.Prefix
-
-	cids := make([]cid.Cid, n)
-	for i := 0; i < n; i++ {
-		b := make([]byte, 10*n)
-		rng.Read(b)
-		c, err := prefix.Sum(b)
-		require.NoError(t, err)
-		cids[i] = c
-	}
-	return cids
-}
-
-func RandomMultihashes(t testing.TB, rng *rand.Rand, n int) []multihash.Multihash {
-	prefix := schema.Linkproto.Prefix
-
-	mhashes := make([]multihash.Multihash, n)
-	for i := 0; i < n; i++ {
-		b := make([]byte, 10*n)
-		rng.Read(b)
-		c, err := prefix.Sum(b)
-		require.NoError(t, err)
-		mhashes[i] = c.Hash()
-	}
-	return mhashes
-}
 
 // ThisDir gets the current directory of the source file its called in
 func ThisDir(t *testing.T) string {
@@ -173,20 +130,6 @@ func WaitForAddrs(h host.Host) peer.AddrInfo {
 		addrInfo = h.Peerstore().PeerInfo(h.ID())
 	}
 	return addrInfo
-}
-
-func GenerateKeysAndIdentity(t *testing.T) (crypto.PrivKey, crypto.PubKey, peer.ID) {
-	priv, pub, err := crypto.GenerateEd25519Key(crand.Reader)
-	require.NoError(t, err)
-	pID, err := peer.IDFromPrivateKey(priv)
-	require.NoError(t, err)
-	return priv, pub, pID
-}
-
-func ContextWithTimeout(t *testing.T) context.Context {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	t.Cleanup(cancel)
-	return ctx
 }
 
 func MultiAddsToString(addrs []multiaddr.Multiaddr) []string {


### PR DESCRIPTION
The logic is simpler to call because random generators do not need a random generator as an argument. Avoids having the same test code in multiple places.