### PR TITLE
Some improvements to index provider delegated routing

### DIFF
--- a/delegatedrouting/chunker.go
+++ b/delegatedrouting/chunker.go
@@ -60,7 +60,7 @@ func (ch *chunker) removeChunk(chunk *cidsChunk) {
 }
 
 func (ch *chunker) setNewCurrentChunk() {
-	ch.currentChunk = &cidsChunk{Cids: make(map[cid.Cid]struct{}, ch.chunkSizeFunc())}
+	ch.currentChunk = &cidsChunk{Cids: make(map[cid.Cid]struct{}, ch.chunkSizeFunc()), Removed: false}
 	ch.currentChunkTime = time.Now()
 }
 

--- a/delegatedrouting/chunker.go
+++ b/delegatedrouting/chunker.go
@@ -21,6 +21,8 @@ type chunker struct {
 type cidsChunk struct {
 	ContextID []byte
 	Cids      map[cid.Cid]struct{}
+	// unused field left for backward compatibility purposes
+	Removed bool
 }
 
 func defaultNonceGen() []byte {

--- a/delegatedrouting/chunker.go
+++ b/delegatedrouting/chunker.go
@@ -21,7 +21,6 @@ type chunker struct {
 type cidsChunk struct {
 	ContextID []byte
 	Cids      map[cid.Cid]struct{}
-	Removed   bool
 }
 
 func defaultNonceGen() []byte {
@@ -59,7 +58,7 @@ func (ch *chunker) removeChunk(chunk *cidsChunk) {
 }
 
 func (ch *chunker) setNewCurrentChunk() {
-	ch.currentChunk = &cidsChunk{Cids: make(map[cid.Cid]struct{}, ch.chunkSizeFunc()), Removed: false}
+	ch.currentChunk = &cidsChunk{Cids: make(map[cid.Cid]struct{}, ch.chunkSizeFunc())}
 	ch.currentChunkTime = time.Now()
 }
 

--- a/delegatedrouting/ds_wrapper.go
+++ b/delegatedrouting/ds_wrapper.go
@@ -73,6 +73,12 @@ func (dsw *dsWrapper) initialiseChunksFromDatastore(ctx context.Context, chunkIm
 			if err != nil {
 				return fmt.Errorf("error deserialising record from the datastore: %w", err)
 			}
+
+			// not importing removed chunks. Left here for backward compatibility purposes
+			if chunk.Removed {
+				continue
+			}
+
 			totalCids += len(chunk.Cids)
 			chunkImporter(chunk)
 		}

--- a/delegatedrouting/ds_wrapper.go
+++ b/delegatedrouting/ds_wrapper.go
@@ -44,13 +44,12 @@ func (dsw *dsWrapper) initialiseFromTheDatastore(ctx context.Context, cidImporte
 
 func (dsw *dsWrapper) initialiseChunksFromDatastore(ctx context.Context, chunkImporter func(c *cidsChunk)) error {
 	offset := 0
-	removedChunks := 0
 	totalCids := 0
 	start := time.Now()
 	// reading all cid chunks from the datastore and adding them up to the in-memory indexes
 	for {
 		pageNum := offset / dsw.pageSize
-		log.Infof("Reading chunk page %d from the datastore. totalChunks=%d, removedChunks=%d, totalCids=%d", pageNum, pageNum*dsw.pageSize, removedChunks, totalCids)
+		log.Infof("Reading chunk page %d from the datastore. totalChunks=%d, totalCids=%d", pageNum, pageNum*dsw.pageSize, totalCids)
 
 		q := dsq.Query{
 			Prefix: chunkByContextIdIndexPrefix,
@@ -72,11 +71,6 @@ func (dsw *dsWrapper) initialiseChunksFromDatastore(ctx context.Context, chunkIm
 			chunk, err := deserialiseChunk(r.Value)
 			if err != nil {
 				return fmt.Errorf("error deserialising record from the datastore: %w", err)
-			}
-			// not importing removed chunks. They can be lazy loaded when needed.
-			if chunk.Removed {
-				removedChunks++
-				continue
 			}
 			totalCids += len(chunk.Cids)
 			chunkImporter(chunk)
@@ -269,6 +263,10 @@ func (dsw *dsWrapper) recordChunkByContextID(ctx context.Context, chunk *cidsChu
 		return err
 	}
 	return dsw.ds.Put(ctx, chunkByContextIDKey(chunk.ContextID), b.Bytes())
+}
+
+func (dsw *dsWrapper) deleteChunk(ctx context.Context, chunk *cidsChunk) error {
+	return dsw.ds.Delete(ctx, chunkByContextIDKey(chunk.ContextID))
 }
 
 func (dsw *dsWrapper) getChunkByContextID(ctx context.Context, contextID []byte) (*cidsChunk, error) {

--- a/delegatedrouting/ds_wrapper.go
+++ b/delegatedrouting/ds_wrapper.go
@@ -55,6 +55,7 @@ func (dsw *dsWrapper) initialiseChunksFromDatastore(ctx context.Context, chunkIm
 			Prefix: chunkByContextIdIndexPrefix,
 			Offset: offset,
 			Limit:  dsw.pageSize,
+			Orders: []dsq.Order{dsq.OrderByKey{}},
 		}
 		ccResults, err := dsw.ds.Query(ctx, q)
 		if err != nil {

--- a/delegatedrouting/listener.go
+++ b/delegatedrouting/listener.go
@@ -373,7 +373,7 @@ func (listener *Listener) removeExpiredCids(ctx context.Context) (bool, error) {
 		}
 		chunksRemoved++
 
-		replacementChunk := &cidsChunk{Cids: make(map[cid.Cid]struct{}, listener.chunkSize)}
+		replacementChunk := &cidsChunk{Cids: make(map[cid.Cid]struct{}, listener.chunkSize), Removed: false}
 
 		for c := range chunkToRemove.Cids {
 			// if cid hasn't expired - adding it to the replacement chunk

--- a/delegatedrouting/listener.go
+++ b/delegatedrouting/listener.go
@@ -147,14 +147,21 @@ func New(ctx context.Context, engine provider.Interface,
 	}, func(chunk *cidsChunk) {
 		// Do not need to add chunk to the in-memory index as old chunks have been already processed by the engine
 		now := time.Now()
-		// some timestamps might be missing in the case if the latest snapshot hasn't been persisted due to an error
-		// while some chunks containing those CIDs haven been persisted and sent out. In that case - backfilling the
-		// missing CIDs with the current timestamp. That is safe to do. Even if those CIDs have expired, they will still
-		// expire from the index-provider just at a later date.
 		for c := range chunk.Cids {
-			if listener.cidQueue.getNodeByCid(c) != nil {
+			// if the cid has already been registered - assign the chunk to it
+			if elem := listener.cidQueue.getNodeByCid(c); elem != nil {
+				node := elem.Value.(*cidNode)
+				if node.chunk != nil {
+					log.Warnf("Chunk for CID %s has already been assigned. This should never happen", c.String())
+				}
+				node.chunk = chunk
 				continue
 			}
+			// if the cid hasn't been registered then backfill it with the curent timestamp.
+			// some timestamps might be missing in the case if the latest snapshot hasn't been persisted due to an error
+			// while some chunks containing those CIDs haven been persisted and sent out. In that case - backfilling the
+			// missing CIDs with the current timestamp. That is safe to do. Even if those CIDs have expired, they will still
+			// expire from the index-provider just at a later date.
 			listener.cidQueue.recordCidNode(&cidNode{C: c, Timestamp: now, chunk: chunk})
 		}
 

--- a/delegatedrouting/listener_api_test.go
+++ b/delegatedrouting/listener_api_test.go
@@ -42,7 +42,7 @@ func ChunkExists(ctx context.Context, listener *Listener, cids []cid.Cid, nonceG
 		return false
 	}
 
-	return !chunkFromDatastore.Removed
+	return true
 }
 
 func HasSnapshot(ctx context.Context, listener *Listener) bool {
@@ -79,12 +79,9 @@ func ChunkNotExist(ctx context.Context, listener *Listener, cids []cid.Cid, nonc
 		return false
 	}
 
-	chunkFromDatastore, err := listener.dsWrapper.getChunkByContextID(ctx, ctxID)
-	if err != nil {
-		return false
-	}
-	return chunkFromDatastore.Removed && listener.chunker.getChunkByContextID(ctxIDStr) == nil
+	_, err := listener.dsWrapper.getChunkByContextID(ctx, ctxID)
 
+	return err == datastore.ErrNotFound && listener.chunker.getChunkByContextID(ctxIDStr) == nil
 }
 
 func CidExist(ctx context.Context, listener *Listener, c cid.Cid, requireChunk bool) bool {

--- a/delegatedrouting/listener_test.go
+++ b/delegatedrouting/listener_test.go
@@ -1072,15 +1072,18 @@ func verifyInitialisationFromDatastore(t *testing.T, snapshotSize int, ttl time.
 	// - all cids have been initialised form the datastore
 	// - cids that have not been included into a chunk should not have been initialised form the datastore
 	for i := 0; i < len(testCids); i += chunkSize {
-		if i+chunkSize < len(testCids) {
+		// this is the last chunk, so iterate through the cids and check that even though the cids have been loaded, they don't have any chunk assigned to them
+		if i+chunkSize > len(testCids) {
 			for j := i; j < len(testCids); j++ {
 				require.True(t, drouting.CidExist(ctx, listener2, testCids[j], false))
 			}
 			break
 		}
-		require.True(t, drouting.ChunkExists(ctx, listener2, testCids[i:i+chunkSize], testNonceGen))
-		for j := 0; j < chunkSize; j++ {
-			require.True(t, drouting.CidExist(ctx, listener2, testCids[i+j], true))
+		// if this is not the last chunk, then verify that
+		// - chunk for the cids exists in in-memory index
+		// - each of the cids has a chunk assigned to it
+		for j := i; j < i+chunkSize; j++ {
+			require.True(t, drouting.CidExist(ctx, listener2, testCids[j], true))
 		}
 	}
 


### PR DESCRIPTION
* Chunks for removed advertisements aren't stored in the datastore anymore, that will allow to improve initialisation time significantly especially for long running nodes;
* Fixes a bug when chunks got paged incorrectly on initialisation. That resulted into some chunks not being loaded at all and some got duplicated;
* Fixes a bug when chunk hasn't been assigned to CIDs on initialisation which resulted into all CIDs being treated was "new".