### PR TITLE
feat: allow extended provider ad builder to set ad entries

### DIFF
--- a/engine/xproviders/xproviders.go
+++ b/engine/xproviders/xproviders.go
@@ -30,6 +30,8 @@ type AdBuilder struct {
 	override bool
 	// lastAdID contains optional last ad cid which is cid.Undef by default
 	lastAdID cid.Cid
+	// entries is the CID of the entries the ad applies to
+	entries cid.Cid
 }
 
 // Info contains information about extended provider.
@@ -86,6 +88,12 @@ func (pub *AdBuilder) WithLastAdID(lastAdID cid.Cid) *AdBuilder {
 	return pub
 }
 
+// WithEntries sets the CID of the entries for the ad
+func (pub *AdBuilder) WithEntries(entries cid.Cid) *AdBuilder {
+	pub.entries = entries
+	return pub
+}
+
 // BuildAndSign verifies and  signs a new extended provider ad. After that it can be published using engine. Identity of the main provider will be appended to the
 // extended provider list automatically.
 func (pub *AdBuilder) BuildAndSign() (*schema.Advertisement, error) {
@@ -93,9 +101,14 @@ func (pub *AdBuilder) BuildAndSign() (*schema.Advertisement, error) {
 		return nil, errors.New("override is true for empty context")
 	}
 
+	entries := schema.NoEntries
+	if pub.entries != cid.Undef {
+		entries = cidlink.Link{Cid: pub.entries}
+	}
+
 	adv := schema.Advertisement{
 		Provider:  pub.providerID,
-		Entries:   schema.NoEntries,
+		Entries:   entries,
 		Addresses: pub.addrs,
 		ContextID: pub.contextID,
 		Metadata:  pub.metadata,

--- a/engine/xproviders/xproviders_test.go
+++ b/engine/xproviders/xproviders_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/ipfs/go-cid"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/ipni/go-libipni/ingest/schema"
 	"github.com/ipni/go-libipni/test"
 	"github.com/ipni/index-provider/engine"
@@ -179,6 +180,22 @@ func TestExtendedProvidersShouldNotAllowInvalidPeerIDs(t *testing.T) {
 		WithMetadata(metadata).
 		BuildAndSign()
 	require.Error(t, err, "invalid extended provider peer id")
+}
+
+func TestExtendedProvidersShouldAllowEntries(t *testing.T) {
+	addrs := test.RandomMultiaddrs(1)
+	providerID, priv, _ := test.RandomIdentity()
+	entries := test.RandomCids(1)[0]
+
+	ad, err := ep.NewAdBuilder(providerID, priv, addrs).
+		WithEntries(entries).
+		BuildAndSign()
+	require.NoError(t, err)
+
+	_, err = ad.VerifySignature()
+	require.NoError(t, err)
+
+	require.Equal(t, cidlink.Link{Cid: entries}, ad.Entries)
 }
 
 func TestZeroExtendedProvidersShouldStillCreateExtendedProvidersField(t *testing.T) {


### PR DESCRIPTION
This PR adds a `WithEntries` method to the extended provider advertisement builder that allows it to set advertisement entries.

Fixes https://github.com/ipni/storetheindex/issues/1725 