### PR TITLE
Get version information from embedded build info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,16 @@
 MAKEFLAGS += --warn-undefined-variables
 MAKEFLAGS += --no-builtin-rules
 
-TAG ?= $(shell git fetch --tags && git describe --tags --abbrev=0 | sed 's/v//')
-COMMIT ?= $(shell git rev-parse --short HEAD)
-CLEAN ?= $(shell git diff --quiet --exit-code || echo '-SNAPSHOT')
-VERSION = $(TAG)$(CLEAN)-$(COMMIT)
-
 .PHONY: all
 all: vet test build
 
 .PHONY: build
 build:
-	go build -ldflags="-X 'main.version=$(VERSION)'" ./cmd/provider 
+	go build ./cmd/provider 
 
 .PHONY: docker
 docker: clean
-	docker build . --force-rm -f Dockerfile -t index-provider:$(VERSION)
+	docker build . --force-rm -f Dockerfile -t index-provider:$(shell git rev-parse --short HEAD)
 
 .PHONY: install
 install:

--- a/cmd/provider/provider.go
+++ b/cmd/provider/provider.go
@@ -7,10 +7,9 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/ipni/index-provider"
 	"github.com/urfave/cli/v2"
 )
-
-var version = "unknown"
 
 func main() {
 	os.Exit(run())
@@ -35,6 +34,17 @@ func run() int {
 		// Allow any further SIGTERM or SIGING to kill the process
 		signal.Stop(interrupt)
 	}()
+
+	var rev string
+	if provider.Modified {
+		rev = "SNAPSHOT"
+	} else {
+		rev = provider.Revision
+		if len(rev) > 7 {
+			rev = rev[:7]
+		}
+	}
+	version := provider.Release + "-" + rev
 
 	app := &cli.App{
 		Name:    "provider",

--- a/version.go
+++ b/version.go
@@ -1,0 +1,52 @@
+package provider
+
+import (
+	_ "embed"
+	"encoding/json"
+	"runtime/debug"
+)
+
+var (
+	// Release is the release version tag value, e.g. "v1.2.3"
+	Release string
+	// Revision is the git commit hash.
+	Revision string
+	// Version is the full version string: Release-Revision.
+	Version string
+	// Modified indicates if the source tree had local modifications.
+	Modified bool
+)
+
+//go:embed version.json
+var versionJSON []byte
+
+func init() {
+	// Read version from embedded JSON file.
+	var verMap map[string]string
+	json.Unmarshal(versionJSON, &verMap)
+	Release = verMap["version"]
+
+	// If running from a module, try to get the build info.
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+
+	var found int
+
+	// Append the revision to the version.
+	for i := range bi.Settings {
+		switch bi.Settings[i].Key {
+		case "vcs.revision":
+			Revision = bi.Settings[i].Value
+			Version = Release + "-" + Revision
+			found++
+		case "vcs.modified":
+			Modified = bi.Settings[i].Value == "true"
+			found++
+		}
+		if found == 2 {
+			break
+		}
+	}
+}


### PR DESCRIPTION
The version is provided by the version.json file and the revision information is build into the binary by the compiler. Use this information instead of fetching it from github each build.

- Installed binary has version information.
- Builds work even without connectivity to github.