### PR TITLE
Return `ipld.ErrNotExists` when no provider identity is found

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -238,7 +238,19 @@ func (e *Engine) Publish(ctx context.Context, adv schema.Advertisement) (cid.Cid
 			log.Info("Announcing advertisement in pubsub channel and via http")
 		}
 
-		err = e.publisher.UpdateRoot(ctx, c)
+		// The publishers have their own senders of announcements. Further, there is a bespoke sender in the engine
+		// to allow explicit announcements via HTTP. The catch is that their behaviour is inconsistent:
+		// * engine takes pubHttpAnnounceAddrs option to allow configuring which addrs should be announced.
+		//   But those addrs are only used by the bespoke sender, _not_ the HTTP sender inside publishers.
+		//
+		// To work around this issue, check if announce addrs are set, and publisher kind is HTTP, and
+		// if so announce with explicit addresses configured.
+		if len(e.pubHttpAnnounceAddrs) > 0 && e.pubKind == HttpPublisher {
+			err = e.publisher.UpdateRootWithAddrs(ctx, c, e.pubHttpAnnounceAddrs)
+		} else {
+			err = e.publisher.UpdateRoot(ctx, c)
+		}
+
 		if err != nil {
 			log.Errorw("Failed to announce advertisement", "err", err)
 			return cid.Undef, err

--- a/engine/linksystem.go
+++ b/engine/linksystem.go
@@ -94,7 +94,7 @@ func (e *Engine) mkLinkSystem() ipld.LinkSystem {
 			key, err := e.getCidKeyMap(ctx, c)
 			if err != nil {
 				if errors.Is(err, datastore.ErrNotFound) {
-					log.Error("No mapping of between CID and contextID to provider identity found. Treating ad as skippable.")
+					log.Error("No mapping between CID and contextID to provider identity found. Treating ad as skippable.")
 					// We have to return ipld.ErrNotExists because the version of storetheindex Boost is using depends
 					// on the old HTTP publisher that only treats this error as 404.
 					return nil, ipld.ErrNotExists{}

--- a/engine/linksystem.go
+++ b/engine/linksystem.go
@@ -93,6 +93,12 @@ func (e *Engine) mkLinkSystem() ipld.LinkSystem {
 			// as same entries from different providers would result into the same chunks
 			key, err := e.getCidKeyMap(ctx, c)
 			if err != nil {
+				if errors.Is(err, datastore.ErrNotFound) {
+					log.Error("No mapping of between CID and contextID to provider identity found. Treating ad as skippable.")
+					// We have to return ipld.ErrNotExists because the version of storetheindex Boost is using depends
+					// on the old HTTP publisher that only treats this error as 404.
+					return nil, ipld.ErrNotExists{}
+				}
 				log.Errorf("Error fetching relationship between CID and contextID: %s", err)
 				return nil, err
 			}

--- a/engine/linksystem_test.go
+++ b/engine/linksystem_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/ipfs/go-cid"
-	"github.com/ipfs/go-datastore"
 	"github.com/ipld/go-car/v2/index"
 	"github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
@@ -98,7 +97,7 @@ func Test_RemovalAdvertisementWithNoEntriesIsRetrievable(t *testing.T) {
 
 	// Assert chunks from advertisement that added content are not found
 	_, err = subject.LinkSystem().Load(lCtx, adAdd.Entries, schema.EntryChunkPrototype)
-	require.Equal(t, datastore.ErrNotFound, err)
+	require.Equal(t, ipld.ErrNotExists{}, err)
 }
 
 func Test_EvictedCachedEntriesChainIsRegeneratedGracefully(t *testing.T) {


### PR DESCRIPTION
In a case where no provider identity is found, skip over the entry to unblock ad processing.