### PR TITLE
Rebase patch release fixes onto `main`

### DIFF
--- a/engine/linksystem.go
+++ b/engine/linksystem.go
@@ -94,7 +94,7 @@ func (e *Engine) mkLinkSystem() ipld.LinkSystem {
 			key, err := e.getCidKeyMap(ctx, c)
 			if err != nil {
 				if errors.Is(err, datastore.ErrNotFound) {
-					log.Error("No mapping of between CID and contextID to provider identity found. Treating ad as skippable.")
+					log.Error("No mapping between CID and contextID to provider identity found. Treating ad as skippable.")
 					// We have to return ipld.ErrNotExists because the version of storetheindex Boost is using depends
 					// on the old HTTP publisher that only treats this error as 404.
 					return nil, ipld.ErrNotExists{}

--- a/engine/linksystem.go
+++ b/engine/linksystem.go
@@ -93,6 +93,12 @@ func (e *Engine) mkLinkSystem() ipld.LinkSystem {
 			// as same entries from different providers would result into the same chunks
 			key, err := e.getCidKeyMap(ctx, c)
 			if err != nil {
+				if errors.Is(err, datastore.ErrNotFound) {
+					log.Error("No mapping of between CID and contextID to provider identity found. Treating ad as skippable.")
+					// We have to return ipld.ErrNotExists because the version of storetheindex Boost is using depends
+					// on the old HTTP publisher that only treats this error as 404.
+					return nil, ipld.ErrNotExists{}
+				}
 				log.Errorf("Error fetching relationship between CID and contextID: %s", err)
 				return nil, err
 			}

--- a/engine/linksystem_test.go
+++ b/engine/linksystem_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/ipfs/go-cid"
-	"github.com/ipfs/go-datastore"
 	"github.com/ipld/go-car/v2/index"
 	"github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
@@ -98,7 +97,7 @@ func Test_RemovalAdvertisementWithNoEntriesIsRetrievable(t *testing.T) {
 
 	// Assert chunks from advertisement that added content are not found
 	_, err = subject.LinkSystem().Load(lCtx, adAdd.Entries, schema.EntryChunkPrototype)
-	require.Equal(t, datastore.ErrNotFound, err)
+	require.Equal(t, ipld.ErrNotExists{}, err)
 }
 
 func Test_EvictedCachedEntriesChainIsRegeneratedGracefully(t *testing.T) {


### PR DESCRIPTION
Rebase the latest patch fixes released as part of `v0.11.3` onto `main`.