### PR TITLE
Option to enable/disable pubsub announcement

### DIFF
--- a/cmd/provider/connect.go
+++ b/cmd/provider/connect.go
@@ -32,6 +32,8 @@ func connectCommand(cctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
+
 	// Handle failed requests
 	if resp.StatusCode != http.StatusOK {
 		return errFromHttpResp(resp)

--- a/cmd/provider/daemon.go
+++ b/cmd/provider/daemon.go
@@ -159,6 +159,7 @@ func daemonCommand(cctx *cli.Context) error {
 		engine.WithPublisherKind(engine.PublisherKind(cfg.Ingest.PublisherKind)),
 		engine.WithHttpPublisherListenAddr(httpListenAddr),
 		engine.WithHttpPublisherAnnounceAddr(cfg.Ingest.HttpPublisher.AnnounceMultiaddr),
+		engine.WithPubsubAnnounce(!cfg.DirectAnnounce.NoPubsubAnnounce),
 		engine.WithSyncPolicy(syncPolicy),
 		engine.WithRetrievalAddrs(cfg.ProviderServer.RetrievalMultiaddrs...),
 	)

--- a/cmd/provider/import.go
+++ b/cmd/provider/import.go
@@ -81,7 +81,6 @@ func beforeImportCar(cctx *cli.Context) error {
 }
 
 func doImportCar(cctx *cli.Context) error {
-
 	mdBytes, err := md.MarshalBinary()
 	if err != nil {
 		return err
@@ -101,6 +100,8 @@ func doImportCar(cctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode != http.StatusOK {
 		return errFromHttpResp(resp)
 	}

--- a/cmd/provider/internal/config/announce.go
+++ b/cmd/provider/internal/config/announce.go
@@ -8,6 +8,10 @@ import (
 // DirectAnnounce configures the target indexers that advertisement announce
 // messages are sent directly to via HTTP.
 type DirectAnnounce struct {
+	// NoPubsubAnnounce disables pubsub announce when set to true. The default
+	// behavior (false) is to enable sending advertisement announcements via
+	// gossib pubsub.
+	NoPubsubAnnounce bool
 	// URLs is a list of indexer URLs to send HTTP announce messages to.
 	URLs []string
 }

--- a/cmd/provider/remove.go
+++ b/cmd/provider/remove.go
@@ -79,6 +79,7 @@ func doRemoveCar(cctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		return errFromHttpResp(resp)

--- a/doc/publisher-config.md
+++ b/doc/publisher-config.md
@@ -21,9 +21,9 @@ The index-provider engine must be configured to use a libp2p publisher, HTTP pub
 - `Libp2pHttpPublisher` serves advertisements using both HTTP and libp2p servers.
 - `DataTransferPublisher` exposes a data-transfer/graphsync server that allows peers in the network to sync advertisements. This option is being discontinued. Only provided as a fallback in case HttpPublisher and Libp2pHttpPublisher are not working.
 
-If `WithPublisherKind` is not provided a value, it defaults to `NoPublisher` and advertisements are only stored locally and no announcements are made. If configuring the command-line application, `WithPublisherKind` is configured by setting the `config.Ingest.PublisherKind` item in the configuration file to a value of "http", "libp2p", "libp2phttp, "dtsync", or "".
+If `WithPublisherKind` is not provided a value, it defaults to `NoPublisher` and advertisements are only stored locally and no announcements are made. If configuring the command-line application, `WithPublisherKind` is configured by setting the `Ingest.PublisherKind` item in the configuration file to a value of "http", "libp2p", "libp2phttp, "dtsync", or "".
 
-For all publisher kinds, except the `DataTransfer` publisher, the `WithHttpPublisherAnnounceAddr` option sets the addresses that are announced to indexers, telling the indexers where to fetch advertisements from. If configuring the command-line application, `WithHttpPublisherAnnounceAddr` is configured by specifying multiaddr strings in `config.Ingest.HttpPublisher.AnnounceMultiaddr`.
+For all publisher kinds, except the `DataTransfer` publisher, the `WithHttpPublisherAnnounceAddr` option sets the addresses that are announced to indexers, telling the indexers where to fetch advertisements from. If configuring the command-line application, `WithHttpPublisherAnnounceAddr` is configured by specifying multiaddr strings in `Ingest.HttpPublisher.AnnounceMultiaddr`.
 
 In future index-provider releases support for the DataTransfer publisher kind will be removed.
 
@@ -31,7 +31,7 @@ In future index-provider releases support for the DataTransfer publisher kind wi
 
 When a new advertisement is made available by a publisher, the new advertisement's CID is generally announced to one or more indexers. An announcement message is constructed and is sent to indexers over libp2p gossip pubsub where it is received by any indexers subscribed to the topic on which the message was publisher. The announcement message may also be sent directly to specific indexers via HTTP.
 
-The `WithDirectAnnounce` option enables sending announcements directly, via HTTP, to the indexer URLs speciied. If this option isnot configured or no URLs specified, then direct HTTP announcement is disabled. The corresponding config file item is `config.DirectAnnounce.URLs`. The `WithPubsubAnnounce` option configures whether or not to broadcast announcements to all subscribed indexers. The corresponding config file item is `config.DirectAnnounce.NoPubsubAnnounce`.
+The `WithDirectAnnounce` option enables sending announcements directly, via HTTP, to the indexer URLs specified. If this option is not configured or no URLs specified, then direct HTTP announcement is disabled. The corresponding config file item is `DirectAnnounce.URLs`. The `WithPubsubAnnounce` option configures whether or not to broadcast announcements to all subscribed indexers. The corresponding config file item is `DirectAnnounce.NoPubsubAnnounce`.
 
 One, both, or none of these announcement methods may be used to make announcements for the publisher, without regard to what kind of publisher is configured. It is only necessary that the announcement message is created with one or more addresses that indexers can use to contact the publisher. The address(es) configured by `WithHttpPublisherAnnounceAddr` may depend on the type of publisher. Otherwise, the configuration of announcement senders is totally separate from the publisher.
 
@@ -39,7 +39,7 @@ If using a plain HTTP server, then provide addresses that specify the "http" or 
 
 ## Configure HTTP server `HttpPublisher` publisher kind
 
-The publisher can be configured to server HTTP using a plain (non-libp2p) HTTP server. This is configured by calling `WithPublisherKind(HttpPublisher)`. If configuring the command-line application, this is set in the configuration file as `config.Ingest.HttpPublisher.ListenMultiaddr`.
+The publisher can be configured to server HTTP using a plain (non-libp2p) HTTP server. This is configured by calling `WithPublisherKind(HttpPublisher)`. If configuring the command-line application, this is set in the configuration file as `Ingest.HttpPublisher.ListenMultiaddr`.
 
 The publisher's HTTP listen address is configured using the engine option `WithHttpPublisherListenAddr`. If unset, the default net listen address of '0.0.0.0:3104' is used.
 
@@ -53,7 +53,7 @@ The `HttpPublisher` kind can use either the publisher's HTTP server, or use an e
 
 This is the default for the `HttpPublisher`.
 
-At least one HTTP listen address is required for the HTTP server to listen on. An HTTP listen address is supplied by the `WithHttpPublisherListenAddr` option. The corresponding config file item is `config.Ingest.HttpPublisher.ListenMultiaddr`. If left unspecified a default listen address is provided. This does not apply if using one of the http provider kinds.
+At least one HTTP listen address is required for the HTTP server to listen on. An HTTP listen address is supplied by the `WithHttpPublisherListenAddr` option. The corresponding config file item is `Ingest.HttpPublisher.ListenMultiaddr`. If left unspecified a default listen address is provided. This does not apply if using one of the http provider kinds.
 
 #### Existing HTTP server
 
@@ -79,7 +79,7 @@ When serving HTTP over libp2p, it is not necessary to specify a publisher HTTP l
 
 The engine always has a libp2p stream host supplied to it with the `WithHost` option or created internally. This libp2p host is give to the engine's HTTP publisher. The private key associated with the libp2p host's Identity is given to the engine using the `WithPrivateKey` option, and is also given to the publisher. This allows advertisements to be signed.
 
-If using the command-line, the libp2p host Identity and private key are configured using the `config.Identiry.PeerID` and `config.Identity.PrivKey` configuration file items. The libp2p host's listen address is configured using the config file item `config.ProviderServer.ListenMultiaddr`.
+If using the command-line, the libp2p host Identity and private key are configured using the `Identiry.PeerID` and `Identity.PrivKey` configuration file items. The libp2p host's listen address is configured using the config file item `ProviderServer.ListenMultiaddr`.
 
 ## Configure HTTP over libp2p and HTTP with `Libp2pHttpPublisher` publisher kind
 
@@ -93,15 +93,15 @@ Publishing with data-transfer/graphsync is legacy configuration, and is only sup
 
 - Tell indexers where to fetch advertisements from:
   - `WithHttpPublisherAnnounceAddr`
-  - `"config"."Ingest"."HttpPublisher"."AnnounceMultiaddr"`
+  - `"Ingest"."HttpPublisher"."AnnounceMultiaddr"`
 - Listen for plain HTTP requests for advertisements
   - `WithHttpPublisherListenAddr`
-  - `"config"."Ingest"."HttpPublisher"."ListenMultiaddr"`
+  - `"Ingest"."HttpPublisher"."ListenMultiaddr"`
 - Tell retrieval clients where to retrieve content from, by advertising these addrs:
   - `WithRetrievalAddrs`
-  - `"ProviderServer"."RetrievalMultiaddrs"
+  - `"ProviderServer"."RetrievalMultiaddrs"`
 - Configure the interface that the content-retrieval-server listens on and provider ID:
-  - `WithProvider`  
+  - `WithProvider`
   - `"ProviderServer"."ListenMultiaddr"
 - Send advertisement announcements to specific indexers via HTTP:
   - `WithDirectAnnounce`
@@ -111,4 +111,4 @@ Publishing with data-transfer/graphsync is legacy configuration, and is only sup
  - `"DirectAnnounce"."NoPubsubAnnounce"`
 
 
-A data-transfer publisher is configured by specifying the engine option `WithPublisherKind(DataTransferPublisher)`. When this option is specified, all of the `HttpPublisher` and `Libp2pPublisher` options are ignored. This option is depricated and will not be supported in the future.
+A data-transfer publisher is configured by specifying the engine option `WithPublisherKind(DataTransferPublisher)`. When this option is specified, all of the `HttpPublisher` and `Libp2pPublisher` options are ignored. This option is deprecated and will not be supported in the future.

--- a/doc/publisher-config.md
+++ b/doc/publisher-config.md
@@ -29,11 +29,13 @@ In future index-provider releases support for the DataTransfer publisher kind wi
 
 ## Publishing vs Announcing
 
-When a new advertisement is made available by a publisher, the new advertisement's CID is generally announced to one or more indexers. An announcement message is constructed and is sent to indexers over libp2p gossip pubsub where it is received by any indexers subscribed to the topic on which the message was publisher. Or, the announcement message is sent directly to specific indexers by HTTP.
+When a new advertisement is made available by a publisher, the new advertisement's CID is generally announced to one or more indexers. An announcement message is constructed and is sent to indexers over libp2p gossip pubsub where it is received by any indexers subscribed to the topic on which the message was publisher. The announcement message may also be sent directly to specific indexers via HTTP.
+
+The `WithDirectAnnounce` option enables sending announcements directly, via HTTP, to the indexer URLs speciied. If this option isnot configured or no URLs specified, then direct HTTP announcement is disabled. The corresponding config file item is `config.DirectAnnounce.URLs`. The `WithPubsubAnnounce` option configures whether or not to broadcast announcements to all subscribed indexers. The corresponding config file item is `config.DirectAnnounce.NoPubsubAnnounce`.
 
 One, both, or none of these announcement methods may be used to make announcements for the publisher, without regard to what kind of publisher is configured. It is only necessary that the announcement message is created with one or more addresses that indexers can use to contact the publisher. The address(es) configured by `WithHttpPublisherAnnounceAddr` may depend on the type of publisher. Otherwise, the configuration of announcement senders is totally separate from the publisher.
 
-If using a plain HTTP server, then provide addresses that specify the "http" or "https" protocol. For example "/dns4/ipni.example.com/tcp/80/https" uses "ipni.example.com" as a DNS address that is expected to resolve to a public address that handles TLS termination, and indicated by the "https" portion. If using a Libp2p server, then specify address(es) that your libp2p host can be contacted on _without_ the "http". Specifying multiple addresses to announce is OK. If no addresses are specified, then the listening HTTP addresses are used if there is an HTTP publisher, and the libp2p host addresses are used if there is a libp2p server.
+If using a plain HTTP server, then provide addresses that specify the "http" or "https" protocol. For example "/dns4/ipni.example.com/tcp/80/https" uses "ipni.example.com" as a DNS address that is expected to resolve to a public address that handles TLS termination, as indicated by the "https" portion. If using a Libp2p server, then specify address(es) that your libp2p host can be contacted on _without_ the "http". Specifying multiple addresses to announce is OK. If no addresses are specified, then the listening HTTP addresses are used if there is an HTTP publisher, and the libp2p host addresses are used if there is a libp2p server.
 
 ## Configure HTTP server `HttpPublisher` publisher kind
 
@@ -101,5 +103,12 @@ Publishing with data-transfer/graphsync is legacy configuration, and is only sup
 - Configure the interface that the content-retrieval-server listens on and provider ID:
   - `WithProvider`  
   - `"ProviderServer"."ListenMultiaddr"
-  
-A data-transfer publisher is configured by specifying the engine option `WithPublisherKind(DataTransferPublisher)`. When this option is specified, all of the `HttpPublisher` and `Libp2pPublisher` options are ignored.
+- Send advertisement announcements to specific indexers via HTTP:
+  - `WithDirectAnnounce`
+  - `"DirectAnnounce"."URLs"`
+- Disable/enable sending advertisement announcements via pubsub:
+ - `WithPubsubAnnounce`
+ - `"DirectAnnounce"."NoPubsubAnnounce"`
+
+
+A data-transfer publisher is configured by specifying the engine option `WithPublisherKind(DataTransferPublisher)`. When this option is specified, all of the `HttpPublisher` and `Libp2pPublisher` options are ignored. This option is depricated and will not be supported in the future.

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -56,6 +56,8 @@ type Engine struct {
 
 	publisher dagsync.Publisher
 	senders   []announce.Sender
+	// announceMsg is the message that is logged when an announcement is sent.
+	announceMsg string
 
 	mhLister provider.MultihashLister
 	cblk     sync.Mutex
@@ -116,7 +118,7 @@ func (e *Engine) Start(ctx context.Context) error {
 		return err
 	}
 
-	e.publisher, err = e.newPublisher()
+	e.publisher, err = e.newPublisher(e.pubHttpListenAddr, e.pubHttpHandlerPath)
 	if err != nil {
 		log.Errorw("Failed to create publisher", "err", err)
 		return err
@@ -133,7 +135,7 @@ func (e *Engine) Start(ctx context.Context) error {
 		}
 
 		// If publisher created, then create announcement senders.
-		e.senders, err = e.createSenders()
+		e.senders, err = e.createSenders(e.announceURLs, e.pubsubAnnounce, e.pubsubExtraGossipData)
 		if err != nil {
 			return err
 		}
@@ -142,16 +144,16 @@ func (e *Engine) Start(ctx context.Context) error {
 	return nil
 }
 
-func (e *Engine) newPublisher() (dagsync.Publisher, error) {
+func (e *Engine) newPublisher(httpListenAddr, httpPath string) (dagsync.Publisher, error) {
 	switch e.pubKind {
 	case NoPublisher:
 		log.Info("Remote announcements disabled; all advertisements will only be stored locally.")
 		return nil, nil
 	case HttpPublisher:
 		httpPub, err := ipnisync.NewPublisher(e.lsys, e.key,
-			ipnisync.WithHTTPListenAddrs(e.pubHttpListenAddr),
+			ipnisync.WithHTTPListenAddrs(httpListenAddr),
 			ipnisync.WithHeadTopic(e.pubTopicName),
-			ipnisync.WithHandlerPath(e.pubHttpHandlerPath),
+			ipnisync.WithHandlerPath(httpPath),
 			ipnisync.WithStartServer(!e.pubHttpWithoutServer))
 		if err != nil {
 			return nil, fmt.Errorf("cannot create publisher: %w", err)
@@ -176,9 +178,9 @@ func (e *Engine) newPublisher() (dagsync.Publisher, error) {
 	case Libp2pHttpPublisher:
 		libp2phttpPub, err := ipnisync.NewPublisher(e.lsys, e.key,
 			ipnisync.WithStreamHost(e.h),
-			ipnisync.WithHTTPListenAddrs(e.pubHttpListenAddr),
+			ipnisync.WithHTTPListenAddrs(httpListenAddr),
 			ipnisync.WithHeadTopic(e.pubTopicName),
-			ipnisync.WithHandlerPath(e.pubHttpHandlerPath),
+			ipnisync.WithHandlerPath(httpPath),
 			ipnisync.WithStartServer(!e.pubHttpWithoutServer))
 		if err != nil {
 			return nil, fmt.Errorf("cannot create publisher: %w", err)
@@ -209,33 +211,47 @@ func (e *Engine) newPublisher() (dagsync.Publisher, error) {
 	return nil, fmt.Errorf("unknown publisher kind %s, expecting one of %v", e.pubKind, []PublisherKind{HttpPublisher, Libp2pPublisher, Libp2pHttpPublisher, DataTransferPublisher})
 }
 
-func (e *Engine) createSenders() ([]announce.Sender, error) {
+func (e *Engine) createSenders(announceURLs []*url.URL, pubsubOK bool, extraGossipData []byte) ([]announce.Sender, error) {
 	var senders []announce.Sender
+	var hasHttpSender, hasP2pSender bool
 
 	// If there are announce URLs, then creage an announce sender to send
 	// direct HTTP announce messages to these URLs.
-	if len(e.announceURLs) != 0 {
+	if len(announceURLs) != 0 {
 		id, err := peer.IDFromPrivateKey(e.key)
 		if err != nil {
 			return nil, fmt.Errorf("cannot get peer ID from private key: %w", err)
 		}
-		httpSender, err := httpsender.New(e.announceURLs, id)
+		httpSender, err := httpsender.New(announceURLs, id)
 		if err != nil {
 			return nil, fmt.Errorf("cannot create http announce sender: %w", err)
 		}
 		senders = append(senders, httpSender)
+		hasHttpSender = true
 	}
 
-	// If there is a libp2p host, then create a gossip pubsub announce sender.
-	if e.h != nil {
+	// If pubsub announcements are enabled and there is a libp2p host, then
+	// create a gossip pubsub announce sender.
+	if pubsubOK && e.h != nil {
 		// Create an announce sender to send over gossip pubsub.
 		p2pSender, err := p2psender.New(e.h, e.pubTopicName,
 			p2psender.WithTopic(e.pubTopic),
-			p2psender.WithExtraData(e.pubExtraGossipData))
+			p2psender.WithExtraData(extraGossipData))
 		if err != nil {
 			return nil, fmt.Errorf("cannot create p2p pubsub announce sender: %w", err)
 		}
 		senders = append(senders, p2pSender)
+		hasP2pSender = true
+	}
+
+	if hasHttpSender && hasP2pSender {
+		e.announceMsg = "Announcing advertisement in pubsub channel and via http"
+	} else if hasHttpSender {
+		e.announceMsg = "Announcing advertisement via http"
+	} else if hasP2pSender {
+		e.announceMsg = "Announcing advertisement in pubsub channel"
+	} else {
+		e.announceMsg = "Cannot announce advertisement, no http or pubsub senders configured"
 	}
 
 	return senders, nil
@@ -253,6 +269,8 @@ func (e *Engine) announce(ctx context.Context, c cid.Cid) {
 		// put into the announce message, instead of using the libp2p host's
 		// addresses.
 		err = announce.Send(ctx, c, e.h.Addrs(), e.senders...)
+	case NoPublisher:
+		// Announcements disabled.
 	}
 	if err != nil {
 		log.Errorw("Failed to announce advertisement", "err", err)
@@ -308,17 +326,7 @@ func (e *Engine) Publish(ctx context.Context, adv schema.Advertisement) (cid.Cid
 
 	// Only announce the advertisement CID if publisher is configured.
 	if e.publisher != nil {
-		log := log.With("adCid", c)
-		if len(e.announceURLs) == 0 && e.h != nil {
-			log.Info("Announcing advertisement in pubsub channel")
-		} else if len(e.announceURLs) != 0 && e.h == nil {
-			log.Info("Announcing advertisement via http")
-		} else if len(e.announceURLs) != 0 && e.h != nil {
-			log.Info("Announcing advertisement in pubsub channel and via http")
-		} else {
-			return cid.Undef, fmt.Errorf("unexpected publisher state, no announceURLs or libp2p host")
-		}
-
+		log.Infow(e.announceMsg, "adCid", c)
 		e.publisher.SetRoot(c)
 		e.announce(ctx, c)
 	}
@@ -388,6 +396,10 @@ func (e *Engine) httpAnnounce(ctx context.Context, adCid cid.Cid, announceURLs [
 	if len(announceURLs) == 0 {
 		return nil
 	}
+	if e.publisher == nil {
+		log.Info("No publisher to announce advertisements for")
+		return nil
+	}
 
 	// Create announce message.
 	msg := message.Message{
@@ -397,9 +409,6 @@ func (e *Engine) httpAnnounce(ctx context.Context, adCid cid.Cid, announceURLs [
 	// The publisher kind determines what addresses to put into the announce
 	// message.
 	switch e.pubKind {
-	case NoPublisher:
-		log.Info("Remote announcements disabled")
-		return nil
 	case HttpPublisher, Libp2pPublisher, Libp2pHttpPublisher:
 		// e.pubHttpAnnounceAddrs is always set in newPublisher.
 		msg.SetAddrs(e.pubHttpAnnounceAddrs)

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -228,6 +228,7 @@ func (e *Engine) createSenders(announceURLs []*url.URL, pubsubOK bool, extraGoss
 		}
 		senders = append(senders, httpSender)
 		hasHttpSender = true
+		log.Info("HTTP announcements enabled")
 	}
 
 	// If pubsub announcements are enabled and there is a libp2p host, then
@@ -242,6 +243,7 @@ func (e *Engine) createSenders(announceURLs []*url.URL, pubsubOK bool, extraGoss
 		}
 		senders = append(senders, p2pSender)
 		hasP2pSender = true
+		log.Info("Pubsub announcements enabled")
 	}
 
 	if hasHttpSender && hasP2pSender {

--- a/go.mod
+++ b/go.mod
@@ -17,8 +17,8 @@ require (
 	github.com/ipld/go-codec-dagpb v1.6.0
 	github.com/ipld/go-ipld-adl-hamt v0.0.0-20220616142416-9004dbd839e0
 	github.com/ipld/go-ipld-prime v0.21.0
-	github.com/ipni/go-libipni v0.5.5
-	github.com/libp2p/go-libp2p v0.32.0
+	github.com/ipni/go-libipni v0.5.7
+	github.com/libp2p/go-libp2p v0.32.1
 	github.com/libp2p/go-libp2p-pubsub v0.10.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/multiformats/go-multiaddr v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -349,8 +349,8 @@ github.com/ipld/go-ipld-adl-hamt v0.0.0-20220616142416-9004dbd839e0/go.mod h1:od
 github.com/ipld/go-ipld-prime v0.21.0 h1:n4JmcpOlPDIxBcY037SVfpd1G+Sj1nKZah0m6QH9C2E=
 github.com/ipld/go-ipld-prime v0.21.0/go.mod h1:3RLqy//ERg/y5oShXXdx5YIp50cFGOanyMctpPjsvxQ=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20230102063945-1a409dc236dd h1:gMlw/MhNr2Wtp5RwGdsW23cs+yCuj9k2ON7i9MiJlRo=
-github.com/ipni/go-libipni v0.5.5 h1:xksZe1ainp+h0KjWdK5tv7FJ8RR45l03UjrET7sWZ8c=
-github.com/ipni/go-libipni v0.5.5/go.mod h1:tdT8a9omKLwm4JEB/hV1Tm9b/4TQY7gKI2cJfN7I/5c=
+github.com/ipni/go-libipni v0.5.7 h1:6/JLZGfv3I54ArBKfS+k/ywOCntXtxMcD7qIf8+uexY=
+github.com/ipni/go-libipni v0.5.7/go.mod h1:+S7MXdUoYyrKK37clglSJyzIV8AkQYG5TuMZhLIgJek=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52 h1:QG4CGBqCeuBo6aZlGAamSkxWdgWfZGeE49eUOWJPA4c=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52/go.mod h1:fdg+/X9Gg4AsAIzWpEHwnqd+QY3b7lajxyjE1m4hkq4=
 github.com/jackpal/go-nat-pmp v1.0.2 h1:KzKSgb7qkJvOUTqYl9/Hg/me3pWgBmERKrTGD7BdWus=
@@ -398,8 +398,8 @@ github.com/libp2p/go-cidranger v1.1.0 h1:ewPN8EZ0dd1LSnrtuwd4709PXVcITVeuwbag38y
 github.com/libp2p/go-cidranger v1.1.0/go.mod h1:KWZTfSr+r9qEo9OkI9/SIEeAtw+NNoU0dXIXt15Okic=
 github.com/libp2p/go-flow-metrics v0.1.0 h1:0iPhMI8PskQwzh57jB9WxIuIOQ0r+15PChFGkx3Q3WM=
 github.com/libp2p/go-flow-metrics v0.1.0/go.mod h1:4Xi8MX8wj5aWNDAZttg6UPmc0ZrnFNsMtpsYUClFtro=
-github.com/libp2p/go-libp2p v0.32.0 h1:86I4B7nBUPIyTgw3+5Ibq6K7DdKRCuZw8URCfPc1hQM=
-github.com/libp2p/go-libp2p v0.32.0/go.mod h1:hXXC3kXPlBZ1eu8Q2hptGrMB4mZ3048JUoS4EKaHW5c=
+github.com/libp2p/go-libp2p v0.32.1 h1:wy1J4kZIZxOaej6NveTWCZmHiJ/kY7GoAqXgqNCnPps=
+github.com/libp2p/go-libp2p v0.32.1/go.mod h1:hXXC3kXPlBZ1eu8Q2hptGrMB4mZ3048JUoS4EKaHW5c=
 github.com/libp2p/go-libp2p-asn-util v0.3.0 h1:gMDcMyYiZKkocGXDQ5nsUQyquC9+H+iLEQHwOCZ7s8s=
 github.com/libp2p/go-libp2p-asn-util v0.3.0/go.mod h1:B1mcOrKUE35Xq/ASTmQ4tN3LNzVVaMNmq2NACuqyB9w=
 github.com/libp2p/go-libp2p-pubsub v0.10.0 h1:wS0S5FlISavMaAbxyQn3dxMOe2eegMfswM471RuHJwA=


### PR DESCRIPTION
Make it optional to send announcements via gossip pubsub, instead of always sending them if a libp2p host is present.

This PR also separates announcement sender configuration from publisher configuration.

Other minor updates:
- Always close http response body
- Update go-libp2p and go-libipni

Fixes issue #364

Note: new options and config file remain backward-compatible with boost and with previous indexer-provider installations.