### PR TITLE
Add a hook to fix multihash mismatch errors

### DIFF
--- a/engine/options.go
+++ b/engine/options.go
@@ -7,6 +7,7 @@ import (
 	datatransfer "github.com/filecoin-project/go-data-transfer/v2"
 	"github.com/ipfs/go-datastore"
 	dssync "github.com/ipfs/go-datastore/sync"
+	"github.com/ipld/go-ipld-prime"
 	_ "github.com/ipni/go-libipni/maurl"
 	"github.com/ipni/index-provider/engine/chunker"
 	"github.com/ipni/index-provider/engine/policy"
@@ -102,6 +103,8 @@ type (
 		chunker     chunker.NewChunkerFunc
 
 		syncPolicy *policy.Policy
+
+		storageReadOpenerErrorHook func(lctx ipld.LinkContext, lnk ipld.Link, err error) error
 	}
 )
 
@@ -439,6 +442,16 @@ func WithExtraGossipData(extraData []byte) Option {
 			o.pubsubExtraGossipData = make([]byte, len(extraData))
 			copy(o.pubsubExtraGossipData, extraData)
 		}
+		return nil
+	}
+}
+
+// WithStorageReadOpenerErrorHook allows the calling applicaiton to invoke a custom piece logic whenever a storage read opener error occurs.
+// For example the calling application can delete corrupted / create a new advertisement if the datastore was corrupted for some reason.
+// The calling application can return ipld.ErrNotFound{} to indicate IPNI that this advertisement should be skipped without halting processing of the rest of the chain.
+func WithStorageReadOpenerErrorHook(hook func(ipld.LinkContext, ipld.Link, error) error) Option {
+	return func(o *options) error {
+		o.storageReadOpenerErrorHook = hook
 		return nil
 	}
 }


### PR DESCRIPTION
When a storage read error happens, the calling application can now invoke a custom piece of logic to fix that error in-flight.