### PR TITLE
cmd: allow to set the retrieval peerID, not just the retrieval multiaddr

### DIFF
--- a/cmd/provider/daemon.go
+++ b/cmd/provider/daemon.go
@@ -160,6 +160,7 @@ func daemonCommand(cctx *cli.Context) error {
 		engine.WithHttpPublisherAnnounceAddr(cfg.Ingest.HttpPublisher.AnnounceMultiaddr),
 		engine.WithPubsubAnnounce(!cfg.DirectAnnounce.NoPubsubAnnounce),
 		engine.WithSyncPolicy(syncPolicy),
+		engine.WithRetrievalPeerID(cfg.ProviderServer.RetrievalPeerID),
 		engine.WithRetrievalAddrs(cfg.ProviderServer.RetrievalMultiaddrs...),
 	)
 	if err != nil {

--- a/cmd/provider/internal/config/providerserver.go
+++ b/cmd/provider/internal/config/providerserver.go
@@ -3,6 +3,9 @@ package config
 type ProviderServer struct {
 	// ListenMultiaddr is the multiaddr string for the node's listen address
 	ListenMultiaddr string
+	// RetrievalPeerID is the peer ID to advertise for data retrieval.
+	// Defaults to the provider's libp2p host peer ID.
+	RetrievalPeerID string
 	// RetrievalMultiaddrs are the addresses to advertise for data retrieval.
 	// Defaults to the provider's libp2p host listen addresses.
 	RetrievalMultiaddrs []string

--- a/engine/options.go
+++ b/engine/options.go
@@ -372,6 +372,22 @@ func WithRetrievalAddrs(addrs ...string) Option {
 	}
 }
 
+// WithRetrievalPeerID sets the peerID of where to get the content corresponding to an indexing advertisement.
+// If unspecified, the libp2p host peer ID are used.
+// See: WithHost
+func WithRetrievalPeerID(peerID string) Option {
+	return func(o *options) error {
+		if len(peerID) != 0 {
+			pId, err := peer.Decode(peerID)
+			if err != nil {
+				return fmt.Errorf("bad peer ID %q: %w", peerID, err)
+			}
+			o.provider.ID = pId
+		}
+		return nil
+	}
+}
+
 func WithSyncPolicy(syncPolicy *policy.Policy) Option {
 	return func(o *options) error {
 		o.syncPolicy = syncPolicy


### PR DESCRIPTION
The config would allow us to specify a data retrieval multiaddr, but that is actually not enough as the default peerID (aka, the index-provider itself) is still used in the advertisements.

This PR add the necessary to also override the default peerID, which makes advertisements works as expected.