### PR TITLE
Add WithHandlerPath option to Libp2pPublisher

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -165,6 +165,7 @@ func (e *Engine) newPublisher(httpListenAddr, httpPath string) (dagsync.Publishe
 	case Libp2pPublisher:
 		libp2pPub, err := ipnisync.NewPublisher(e.lsys, e.key,
 			ipnisync.WithStreamHost(e.h),
+			ipnisync.WithHandlerPath(httpPath),
 			ipnisync.WithHeadTopic(e.pubTopicName))
 		if err != nil {
 			return nil, fmt.Errorf("cannot create publisher: %w", err)


### PR DESCRIPTION
For our measurement infrastructure I want to setup a libp2p http host to serve IPNI's advertisement-fetch requests. Previously we were using the `DataTransferPublisher` which is deprecated as I've learned. I wanted to configure the engine to serve the http handler under a certain path but noticed that the options isn't passed through to the libp2p publisher. I hope I'm not misunderstanding anything but I think this plumbing is missing.